### PR TITLE
Add WPF UI library with reusable controls and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Planned
 - Improve documentation
-- Refinement of the public interface
-- Additional logging and error handling
+
+## [0.5.0] - 
+
+### Added
+- Refined the public interface
+- Moved some UI elements from Wpf sample app into a new UI library for Wpf
+- Updated package references in sample applications
 
 ## [0.4.0] - 2026-03-22
 

--- a/samples/AssetManager/AssetManager.csproj
+++ b/samples/AssetManager/AssetManager.csproj
@@ -7,6 +7,6 @@
     <UseWPF>true</UseWPF>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Tudormobile.IronLedgerLib.UI" Version="0.2.0" />
+    <PackageReference Include="Tudormobile.IronLedgerLib.UI" Version="0.4.0" />
   </ItemGroup>
 </Project>

--- a/samples/AssetViewer/AssetViewer.csproj
+++ b/samples/AssetViewer/AssetViewer.csproj
@@ -7,6 +7,6 @@
     <UseWPF>true</UseWPF>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Tudormobile.IronLedgerLib.UI" Version="0.2.0" />
+    <PackageReference Include="Tudormobile.IronLedgerLib.UI" Version="0.4.0" />
   </ItemGroup>
 </Project>

--- a/samples/ServiceClient/ServiceClient.csproj
+++ b/samples/ServiceClient/ServiceClient.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Tudormobile.IronLedgerLib.Services" Version="0.2.0" />
+    <PackageReference Include="Tudormobile.IronLedgerLib.Services" Version="0.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
   </ItemGroup>

--- a/samples/ServiceHost/ServiceHost.csproj
+++ b/samples/ServiceHost/ServiceHost.csproj
@@ -5,6 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Tudormobile.IronLedgerLib.Services" Version="0.2.0" />
+    <PackageReference Include="Tudormobile.IronLedgerLib.Services" Version="0.4.0" />
   </ItemGroup>
 </Project>

--- a/src/IronLedger.slnx
+++ b/src/IronLedger.slnx
@@ -4,5 +4,7 @@
   <Project Path="IronLedgerLib.Tests/IronLedgerLib.Tests.csproj" />
   <Project Path="IronLedgerLib.UI/IronLedgerLib.UI.csproj" />
   <Project Path="IronLedgerLib.UI.Tests/IronLedgerLib.UI.Tests.csproj" />
+  <Project Path="IronLedgerLib.UI.Wpf/IronLedgerLib.UI.Wpf.csproj" />
+  <Project Path="IronLedgerLib.UI.Wpf.Tests/IronLedgerLib.UI.Wpf.Tests.csproj" />
   <Project Path="IronLedgerLib/IronLedgerLib.csproj" />
 </Solution>

--- a/src/IronLedgerLib.UI.Wpf.Tests/Converters/VisibilityConverterTests.cs
+++ b/src/IronLedgerLib.UI.Wpf.Tests/Converters/VisibilityConverterTests.cs
@@ -1,0 +1,209 @@
+using System.Windows;
+using Tudormobile.IronLedgerLib.UI.Wpf.Converters;
+
+namespace IronLedgerLib.UI.Wpf.Tests.Converters;
+
+[TestClass]
+public class VisibilityConverterTests
+{
+    [TestMethod]
+    public void Convert_ShouldReturnVisible_WhenValueIsTrue()
+    {
+        // Arrange
+        var converter = new VisibilityConverter();
+        var value = true;
+
+        // Act
+        var result = converter.Convert(value, null, null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(Visibility.Visible, result);
+    }
+
+    [TestMethod]
+    public void Convert_ShouldReturnCollapsed_WhenValueIsFalse()
+    {
+        // Arrange
+        var converter = new VisibilityConverter();
+        var value = false;
+
+        // Act
+        var result = converter.Convert(value, null, null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(Visibility.Collapsed, result);
+    }
+
+    // --- Null / reference types ---
+
+    [TestMethod]
+    public void Convert_ShouldReturnCollapsed_WhenValueIsNull()
+    {
+        var converter = new VisibilityConverter();
+
+        var result = converter.Convert(null, null, null, CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(Visibility.Collapsed, result);
+    }
+
+    [TestMethod]
+    public void Convert_ShouldReturnVisible_WhenValueIsNonNullObject()
+    {
+        var converter = new VisibilityConverter();
+
+        var result = converter.Convert(new object(), null, null, CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(Visibility.Visible, result);
+    }
+
+    // --- Strings ---
+
+    [TestMethod]
+    public void Convert_ShouldReturnCollapsed_WhenValueIsEmptyString()
+    {
+        var converter = new VisibilityConverter();
+
+        var result = converter.Convert(string.Empty, null, null, CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(Visibility.Collapsed, result);
+    }
+
+    [TestMethod]
+    public void Convert_ShouldReturnCollapsed_WhenValueIsWhitespaceString()
+    {
+        var converter = new VisibilityConverter();
+
+        var result = converter.Convert("   ", null, null, CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(Visibility.Collapsed, result);
+    }
+
+    [TestMethod]
+    public void Convert_ShouldReturnVisible_WhenValueIsNonEmptyString()
+    {
+        var converter = new VisibilityConverter();
+
+        var result = converter.Convert("hello", null, null, CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(Visibility.Visible, result);
+    }
+
+    // --- Value type defaults ---
+
+    [TestMethod]
+    public void Convert_ShouldReturnCollapsed_WhenValueIsDefaultInt()
+    {
+        var converter = new VisibilityConverter();
+
+        var result = converter.Convert(0, null, null, CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(Visibility.Collapsed, result);
+    }
+
+    [TestMethod]
+    public void Convert_ShouldReturnVisible_WhenValueIsNonDefaultInt()
+    {
+        var converter = new VisibilityConverter();
+
+        var result = converter.Convert(42, null, null, CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(Visibility.Visible, result);
+    }
+
+    // --- Parameter = Visibility.Collapsed (explicit non-visible state) ---
+
+    [TestMethod]
+    public void Convert_ShouldReturnCollapsed_WhenParameterIsCollapsedAndValueIsNull()
+    {
+        var converter = new VisibilityConverter();
+
+        var result = converter.Convert(null, null, Visibility.Collapsed, CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(Visibility.Collapsed, result);
+    }
+
+    // --- Parameter = Visibility.Hidden (alternate non-visible state) ---
+
+    [TestMethod]
+    public void Convert_ShouldReturnHidden_WhenParameterIsHiddenAndValueIsNull()
+    {
+        var converter = new VisibilityConverter();
+
+        var result = converter.Convert(null, null, Visibility.Hidden, CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(Visibility.Hidden, result);
+    }
+
+    [TestMethod]
+    public void Convert_ShouldReturnHidden_WhenParameterIsHiddenAndValueIsDefaultInt()
+    {
+        var converter = new VisibilityConverter();
+
+        var result = converter.Convert(0, null, Visibility.Hidden, CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(Visibility.Hidden, result);
+    }
+
+    [TestMethod]
+    public void Convert_ShouldReturnVisible_WhenParameterIsHiddenAndValueIsNonNull()
+    {
+        var converter = new VisibilityConverter();
+
+        var result = converter.Convert("hello", null, Visibility.Hidden, CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(Visibility.Visible, result);
+    }
+
+    // --- Parameter = Visibility.Visible (inverted behavior) ---
+
+    [TestMethod]
+    public void Convert_ShouldReturnVisible_WhenParameterIsVisibleAndValueIsNull()
+    {
+        var converter = new VisibilityConverter();
+
+        var result = converter.Convert(null, null, Visibility.Visible, CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(Visibility.Visible, result);
+    }
+
+    [TestMethod]
+    public void Convert_ShouldReturnVisible_WhenParameterIsVisibleAndValueIsFalse()
+    {
+        var converter = new VisibilityConverter();
+
+        var result = converter.Convert(false, null, Visibility.Visible, CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(Visibility.Visible, result);
+    }
+
+    [TestMethod]
+    public void Convert_ShouldReturnCollapsed_WhenParameterIsVisibleAndValueIsNonNull()
+    {
+        var converter = new VisibilityConverter();
+
+        var result = converter.Convert(new object(), null, Visibility.Visible, CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(Visibility.Collapsed, result);
+    }
+
+    [TestMethod]
+    public void Convert_ShouldReturnCollapsed_WhenParameterIsVisibleAndValueIsTrue()
+    {
+        var converter = new VisibilityConverter();
+
+        var result = converter.Convert(true, null, Visibility.Visible, CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(Visibility.Collapsed, result);
+    }
+
+    // --- ConvertBack ---
+
+    [TestMethod]
+    public void ConvertBack_ShouldThrowNotImplementedException()
+    {
+        var converter = new VisibilityConverter();
+
+        Assert.ThrowsExactly<NotImplementedException>(
+            () => converter.ConvertBack(Visibility.Visible, null, null, CultureInfo.InvariantCulture));
+    }
+}

--- a/src/IronLedgerLib.UI.Wpf.Tests/Converters/VisibilityConverterTests.cs
+++ b/src/IronLedgerLib.UI.Wpf.Tests/Converters/VisibilityConverterTests.cs
@@ -14,7 +14,7 @@ public class VisibilityConverterTests
         var value = true;
 
         // Act
-        var result = converter.Convert(value, null, null, CultureInfo.InvariantCulture);
+        var result = converter.Convert(value, null!, null, CultureInfo.InvariantCulture);
 
         // Assert
         Assert.AreEqual(Visibility.Visible, result);
@@ -28,7 +28,7 @@ public class VisibilityConverterTests
         var value = false;
 
         // Act
-        var result = converter.Convert(value, null, null, CultureInfo.InvariantCulture);
+        var result = converter.Convert(value, null!, null, CultureInfo.InvariantCulture);
 
         // Assert
         Assert.AreEqual(Visibility.Collapsed, result);
@@ -41,7 +41,7 @@ public class VisibilityConverterTests
     {
         var converter = new VisibilityConverter();
 
-        var result = converter.Convert(null, null, null, CultureInfo.InvariantCulture);
+        var result = converter.Convert(null, null!, null, CultureInfo.InvariantCulture);
 
         Assert.AreEqual(Visibility.Collapsed, result);
     }
@@ -51,7 +51,7 @@ public class VisibilityConverterTests
     {
         var converter = new VisibilityConverter();
 
-        var result = converter.Convert(new object(), null, null, CultureInfo.InvariantCulture);
+        var result = converter.Convert(new object(), null!, null, CultureInfo.InvariantCulture);
 
         Assert.AreEqual(Visibility.Visible, result);
     }
@@ -63,7 +63,7 @@ public class VisibilityConverterTests
     {
         var converter = new VisibilityConverter();
 
-        var result = converter.Convert(string.Empty, null, null, CultureInfo.InvariantCulture);
+        var result = converter.Convert(string.Empty, null!, null, CultureInfo.InvariantCulture);
 
         Assert.AreEqual(Visibility.Collapsed, result);
     }
@@ -73,7 +73,7 @@ public class VisibilityConverterTests
     {
         var converter = new VisibilityConverter();
 
-        var result = converter.Convert("   ", null, null, CultureInfo.InvariantCulture);
+        var result = converter.Convert("   ", null!, null, CultureInfo.InvariantCulture);
 
         Assert.AreEqual(Visibility.Collapsed, result);
     }
@@ -83,7 +83,7 @@ public class VisibilityConverterTests
     {
         var converter = new VisibilityConverter();
 
-        var result = converter.Convert("hello", null, null, CultureInfo.InvariantCulture);
+        var result = converter.Convert("hello", null!, null, CultureInfo.InvariantCulture);
 
         Assert.AreEqual(Visibility.Visible, result);
     }
@@ -95,7 +95,7 @@ public class VisibilityConverterTests
     {
         var converter = new VisibilityConverter();
 
-        var result = converter.Convert(0, null, null, CultureInfo.InvariantCulture);
+        var result = converter.Convert(0, null!, null, CultureInfo.InvariantCulture);
 
         Assert.AreEqual(Visibility.Collapsed, result);
     }
@@ -105,7 +105,7 @@ public class VisibilityConverterTests
     {
         var converter = new VisibilityConverter();
 
-        var result = converter.Convert(42, null, null, CultureInfo.InvariantCulture);
+        var result = converter.Convert(42, null!, null, CultureInfo.InvariantCulture);
 
         Assert.AreEqual(Visibility.Visible, result);
     }
@@ -117,7 +117,7 @@ public class VisibilityConverterTests
     {
         var converter = new VisibilityConverter();
 
-        var result = converter.Convert(null, null, Visibility.Collapsed, CultureInfo.InvariantCulture);
+        var result = converter.Convert(null, null!, Visibility.Collapsed, CultureInfo.InvariantCulture);
 
         Assert.AreEqual(Visibility.Collapsed, result);
     }
@@ -129,7 +129,7 @@ public class VisibilityConverterTests
     {
         var converter = new VisibilityConverter();
 
-        var result = converter.Convert(null, null, Visibility.Hidden, CultureInfo.InvariantCulture);
+        var result = converter.Convert(null, null!, Visibility.Hidden, CultureInfo.InvariantCulture);
 
         Assert.AreEqual(Visibility.Hidden, result);
     }
@@ -139,7 +139,7 @@ public class VisibilityConverterTests
     {
         var converter = new VisibilityConverter();
 
-        var result = converter.Convert(0, null, Visibility.Hidden, CultureInfo.InvariantCulture);
+        var result = converter.Convert(0, null!, Visibility.Hidden, CultureInfo.InvariantCulture);
 
         Assert.AreEqual(Visibility.Hidden, result);
     }
@@ -149,7 +149,7 @@ public class VisibilityConverterTests
     {
         var converter = new VisibilityConverter();
 
-        var result = converter.Convert("hello", null, Visibility.Hidden, CultureInfo.InvariantCulture);
+        var result = converter.Convert("hello", null!, Visibility.Hidden, CultureInfo.InvariantCulture);
 
         Assert.AreEqual(Visibility.Visible, result);
     }
@@ -161,7 +161,7 @@ public class VisibilityConverterTests
     {
         var converter = new VisibilityConverter();
 
-        var result = converter.Convert(null, null, Visibility.Visible, CultureInfo.InvariantCulture);
+        var result = converter.Convert(null, null!, Visibility.Visible, CultureInfo.InvariantCulture);
 
         Assert.AreEqual(Visibility.Visible, result);
     }
@@ -171,7 +171,7 @@ public class VisibilityConverterTests
     {
         var converter = new VisibilityConverter();
 
-        var result = converter.Convert(false, null, Visibility.Visible, CultureInfo.InvariantCulture);
+        var result = converter.Convert(false, null!, Visibility.Visible, CultureInfo.InvariantCulture);
 
         Assert.AreEqual(Visibility.Visible, result);
     }
@@ -181,7 +181,7 @@ public class VisibilityConverterTests
     {
         var converter = new VisibilityConverter();
 
-        var result = converter.Convert(new object(), null, Visibility.Visible, CultureInfo.InvariantCulture);
+        var result = converter.Convert(new object(), null!, Visibility.Visible, CultureInfo.InvariantCulture);
 
         Assert.AreEqual(Visibility.Collapsed, result);
     }
@@ -191,7 +191,7 @@ public class VisibilityConverterTests
     {
         var converter = new VisibilityConverter();
 
-        var result = converter.Convert(true, null, Visibility.Visible, CultureInfo.InvariantCulture);
+        var result = converter.Convert(true, null!, Visibility.Visible, CultureInfo.InvariantCulture);
 
         Assert.AreEqual(Visibility.Collapsed, result);
     }
@@ -204,6 +204,68 @@ public class VisibilityConverterTests
         var converter = new VisibilityConverter();
 
         Assert.ThrowsExactly<NotImplementedException>(
-            () => converter.ConvertBack(Visibility.Visible, null, null, CultureInfo.InvariantCulture));
+            () => converter.ConvertBack(Visibility.Visible, null!, null, CultureInfo.InvariantCulture));
+    }
+
+    // --- String parameters ---
+
+    [TestMethod]
+    public void Convert_ShouldReturnHidden_WhenParameterIsStringHiddenAndValueIsNull()
+    {
+        var converter = new VisibilityConverter();
+
+        var result = converter.Convert(null, null!, "Hidden", CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(Visibility.Hidden, result);
+    }
+
+    [TestMethod]
+    public void Convert_ShouldReturnCollapsed_WhenParameterIsStringCollapsedAndValueIsNull()
+    {
+        var converter = new VisibilityConverter();
+
+        var result = converter.Convert(null, null!, "Collapsed", CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(Visibility.Collapsed, result);
+    }
+
+    [TestMethod]
+    public void Convert_ShouldReturnVisible_WhenParameterIsStringVisibleAndValueIsNull()
+    {
+        var converter = new VisibilityConverter();
+
+        var result = converter.Convert(null, null!, "Visible", CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(Visibility.Visible, result);
+    }
+
+    [TestMethod]
+    public void Convert_ShouldReturnCollapsed_WhenParameterIsStringVisibleAndValueIsNonNull()
+    {
+        var converter = new VisibilityConverter();
+
+        var result = converter.Convert("hello", null!, "Visible", CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(Visibility.Collapsed, result);
+    }
+
+    [TestMethod]
+    public void Convert_ShouldBeCaseInsensitive_WhenParameterIsStringInLowercase()
+    {
+        var converter = new VisibilityConverter();
+
+        var result = converter.Convert(null, null!, "hidden", CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(Visibility.Hidden, result);
+    }
+
+    [TestMethod]
+    public void Convert_ShouldIgnoreParameter_WhenParameterIsUnrecognisedString()
+    {
+        var converter = new VisibilityConverter();
+
+        var result = converter.Convert(null, null!, "notavisibility", CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(Visibility.Collapsed, result);
     }
 }

--- a/src/IronLedgerLib.UI.Wpf.Tests/IronLedgerLib.UI.Wpf.Tests.csproj
+++ b/src/IronLedgerLib.UI.Wpf.Tests/IronLedgerLib.UI.Wpf.Tests.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="MSTest.Sdk/4.1.0">
+  <PropertyGroup>
+    <UseWpf>true</UseWpf>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\IronLedgerLib.UI.Wpf\IronLedgerLib.UI.Wpf.csproj" />
+    <Using Include="System.Globalization" />
+    <Using Include="Tudormobile.IronLedgerLib" />
+    <Using Include="Tudormobile.IronLedgerLib.UI" />
+    <Using Include="Tudormobile.IronLedgerLib.UI.Wpf" />
+  </ItemGroup>
+</Project>

--- a/src/IronLedgerLib.UI.Wpf.Tests/MSTestSettings.cs
+++ b/src/IronLedgerLib.UI.Wpf.Tests/MSTestSettings.cs
@@ -1,0 +1,1 @@
+﻿[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]

--- a/src/IronLedgerLib.UI.Wpf/Converters/VisibilityConverter.cs
+++ b/src/IronLedgerLib.UI.Wpf/Converters/VisibilityConverter.cs
@@ -33,6 +33,11 @@ namespace Tudormobile.IronLedgerLib.UI.Wpf.Converters;
 ///     </description>
 ///   </item>
 /// </list>
+/// <para>
+/// The parameter may be a <see cref="Visibility"/> value or a case-insensitive string equivalent
+/// (e.g. <c>"Visible"</c>, <c>"Hidden"</c>), which is the natural form when set via a XAML
+/// <c>ConverterParameter</c> attribute.
+/// </para>
 /// </remarks>
 public class VisibilityConverter : IValueConverter
 {
@@ -40,20 +45,24 @@ public class VisibilityConverter : IValueConverter
     /// Converts a value to a <see cref="Visibility"/>.
     /// </summary>
     /// <param name="value">The value to evaluate.</param>
-    /// <param name="targetType">The target binding type (unused).</param>
+    /// <param name="targetType">
+    /// The target binding type. This converter always returns <see cref="Visibility"/> and does
+    /// not use this parameter; <see langword="null"/> is accepted.
+    /// </param>
     /// <param name="parameter">
-    /// An optional <see cref="Visibility"/> that controls non-visible state or inverts the result.
+    /// An optional <see cref="Visibility"/> value, or its case-insensitive string equivalent
+    /// (e.g. <c>"Visible"</c>, <c>"Hidden"</c>), that controls the non-visible state or inverts the result.
     /// </param>
     /// <param name="culture">The culture to use (unused).</param>
     /// <returns>A <see cref="Visibility"/> value.</returns>
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         var isVisible = IsVisible(value);
 
         var nonVisibleState = Visibility.Collapsed;
         var invert = false;
 
-        if (parameter is Visibility visibilityParameter)
+        if (TryGetVisibilityParameter(parameter, out var visibilityParameter))
         {
             if (visibilityParameter == Visibility.Visible)
             {
@@ -77,9 +86,26 @@ public class VisibilityConverter : IValueConverter
     /// Not supported. Always throws <see cref="NotImplementedException"/>.
     /// </summary>
     /// <inheritdoc/>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         throw new NotImplementedException();
+    }
+
+    private static bool TryGetVisibilityParameter(object? parameter, out Visibility visibility)
+    {
+        if (parameter is Visibility v)
+        {
+            visibility = v;
+            return true;
+        }
+
+        if (parameter is string s && Enum.TryParse(s, ignoreCase: true, out visibility))
+        {
+            return true;
+        }
+
+        visibility = default;
+        return false;
     }
 
     private static bool IsVisible(object? value)

--- a/src/IronLedgerLib.UI.Wpf/Converters/VisibilityConverter.cs
+++ b/src/IronLedgerLib.UI.Wpf/Converters/VisibilityConverter.cs
@@ -1,0 +1,105 @@
+﻿using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Tudormobile.IronLedgerLib.UI.Wpf.Converters;
+
+/// <summary>
+/// Converts a value to a <see cref="Visibility"/> based on whether the value is considered
+/// "present" (visible) or "absent" (non-visible).
+/// </summary>
+/// <remarks>
+/// <para>The following rules determine whether a value is visible:</para>
+/// <list type="bullet">
+///   <item><description><see langword="null"/> → non-visible.</description></item>
+///   <item><description>A value type equal to its default (e.g. <c>0</c>, <c>false</c>) → non-visible.</description></item>
+///   <item><description>A <see cref="string"/> that is <see langword="null"/>, empty, or whitespace → non-visible.</description></item>
+///   <item><description>All other values → visible.</description></item>
+/// </list>
+/// <para>
+/// An optional <see cref="Visibility"/> converter parameter controls output behavior:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <description>
+///       <see cref="Visibility.Collapsed"/> or <see cref="Visibility.Hidden"/> — the non-visible
+///       state produces that specific value instead of the default <see cref="Visibility.Collapsed"/>.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///       <see cref="Visibility.Visible"/> — inverts the conversion: non-visible values produce
+///       <see cref="Visibility.Visible"/> and visible values produce <see cref="Visibility.Collapsed"/>.
+///     </description>
+///   </item>
+/// </list>
+/// </remarks>
+public class VisibilityConverter : IValueConverter
+{
+    /// <summary>
+    /// Converts a value to a <see cref="Visibility"/>.
+    /// </summary>
+    /// <param name="value">The value to evaluate.</param>
+    /// <param name="targetType">The target binding type (unused).</param>
+    /// <param name="parameter">
+    /// An optional <see cref="Visibility"/> that controls non-visible state or inverts the result.
+    /// </param>
+    /// <param name="culture">The culture to use (unused).</param>
+    /// <returns>A <see cref="Visibility"/> value.</returns>
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var isVisible = IsVisible(value);
+
+        var nonVisibleState = Visibility.Collapsed;
+        var invert = false;
+
+        if (parameter is Visibility visibilityParameter)
+        {
+            if (visibilityParameter == Visibility.Visible)
+            {
+                invert = true;
+            }
+            else
+            {
+                nonVisibleState = visibilityParameter;
+            }
+        }
+
+        if (invert)
+        {
+            return isVisible ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        return isVisible ? Visibility.Visible : nonVisibleState;
+    }
+
+    /// <summary>
+    /// Not supported. Always throws <see cref="NotImplementedException"/>.
+    /// </summary>
+    /// <inheritdoc/>
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+
+    private static bool IsVisible(object? value)
+    {
+        if (value is null)
+        {
+            return false;
+        }
+
+        if (value is string stringValue)
+        {
+            return !string.IsNullOrWhiteSpace(stringValue);
+        }
+
+        if (value is ValueType)
+        {
+            var defaultValue = Activator.CreateInstance(value.GetType());
+            return !value.Equals(defaultValue);
+        }
+
+        return true;
+    }
+}

--- a/src/IronLedgerLib.UI.Wpf/IronLedgerLib.UI.Wpf.csproj
+++ b/src/IronLedgerLib.UI.Wpf/IronLedgerLib.UI.Wpf.csproj
@@ -1,0 +1,36 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <UseWPF>true</UseWPF>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <AssemblyName>Tudormobile.$(MSBuildProjectName)</AssemblyName>
+    <RootNamespace>Tudormobile.$(MSBuildProjectName)</RootNamespace>
+    <Product>Iron Ledger Library</Product>
+    <Description>Wpf UI library for Iron Ledger.</Description>
+    <PackageTags>ironledger ledger inventory ITAD IT asset wipe sanitation</PackageTags>
+    <PackageProjectUrl>https://tudormobile.github.io/IronLedger/</PackageProjectUrl>
+    <PackageReleaseNotes>https://github.com/tudormobile/IronLedger/releases</PackageReleaseNotes>
+    <RepositoryUrl>https://github.com/tudormobile/IronLedger</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <Company>Tudormobile</Company>
+    <Authors>WH Tudor</Authors>
+    <Copyright>Copyright © 2026 Bill Tudor</Copyright>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+    <InternalsVisibleTo Include="$(MSBuildProjectName).Tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\IronLedgerLib\IronLedgerLib.csproj" />
+    <ProjectReference Include="..\IronLedgerLib.UI\IronLedgerLib.UI.csproj" />
+  </ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
+</Project>

--- a/src/IronLedgerLib.UI.Wpf/README.md
+++ b/src/IronLedgerLib.UI.Wpf/README.md
@@ -1,0 +1,145 @@
+# IronLedger
+
+[![NuGet](https://img.shields.io/nuget/v/Tudormobile.IronLedgerLib.UI..Wpf.svg)](https://www.nuget.org/packages/Tudormobile.IronLedgerLib.UI.Wpf/)
+[![License](https://img.shields.io/github/license/tudormobile/IronLedger)](https://github.com/tudormobile/IronLedger/blob/main/LICENSE.txt)
+[![.NET](https://img.shields.io/badge/.NET-10.0-blue.svg)](https://dotnet.microsoft.com/download)
+
+**IronLedger** is a comprehensive .NET library for hardware asset identification and inventory management. It provides a robust framework for collecting, serializing, and managing hardware component data across your infrastructure.
+
+## 🎯 Overview
+
+IronLedgerLib enables applications and services to:
+- **Collect hardware data** from system components (CPU, memory, disks, motherboard, BIOS)
+- **Generate unique asset identifiers** based on hardware fingerprints
+- **Serialize and deserialize** asset data using flexible abstractions
+- **Track hardware inventory** with strongly-typed, immutable data structures
+
+IronLedgerLib.UI enables applications and services to:
+- **Observable Entities** from system components (CPU, memory, disks, motherboard, BIOS)
+- **Relay Commands** for management of entities
+- **Service Layer** for orchestration via MVVM patterns.
+
+IronLedgerLib.UI.Wpf enables applications and services to:
+- **Views** to display system assets and components on the Windows Desktop platform
+- **Controls** to manage display snd editing of components on Windows desktop
+
+Perfect for building windows desktop UI applications that leverage the Iron Ledger library.
+
+## ⚙️ Platform Support
+
+| Platform | Status |
+|----------|--------|
+| **Windows** | ✅ Fully Supported |
+| **Linux** | Not supported or planned |
+| **macOS** | Noy supported or planned |
+
+
+## 📦 Installation
+
+Install via NuGet Package Manager:
+
+```bash
+dotnet add package Tudormobile.IronLedgerLib.UI.Wpf
+```
+
+Or via Package Manager Console:
+
+```powershell
+Install-Package Tudormobile.IronLedgerLib.UI.Wpf
+```
+
+Or add directly to your `.csproj`:
+
+```xml
+<PackageReference Include="Tudormobile.IronLedgerLib.UI.Wpf" Version="1.0.0" />
+```
+
+## 🚀 Quick Start
+
+```csharp
+using Tudormobile.IronLedgerLib.UI.Wpf;
+using Tudormobile.IronLedgerLib.UI.Wpf.Views;
+using Tudormobile.IronLedgerLib.UI.Wpf.Controls;
+```
+
+## ✨ Key Features
+
+### 🔑 Unique Asset Identification
+- Generate cryptographic hardware fingerprints using SHA256
+- Combine system, baseboard, and BIOS metadata
+- Consistent, deterministic asset IDs across reboots
+- Hexadecimal string representation for easy storage and comparison
+
+### 📊 Hardware Data Collection
+- **Processors** - CPU details including cores, speed, and specifications
+- **Memory Modules** - RAM information with capacity and type
+- **Disk Drives** - Storage device data including size and model
+- **System Information** - Manufacturer, model, and serial numbers
+- **Baseboard** - Motherboard details and identifiers
+- **BIOS** - Firmware version and vendor information
+
+### 🛡️ Robust Exception Handling
+- Custom exception hierarchy for precise error handling
+- `ComponentDataProviderException` for hardware query failures
+- Comprehensive error context with provider name and WMI class information
+- Standard .NET exceptions for argument validation
+
+### 📝 Flexible Serialization
+- Abstraction-based serialization framework
+- Built-in JSON serializer with System.Text.Json
+- Snake case naming convention for JSON properties
+- Custom converters for component properties
+- Easy to implement custom serializers
+
+### 🔒 Immutable Data Structures
+- Thread-safe, immutable record types
+- Init-only properties prevent accidental modification
+- Structural equality for easy comparison
+- Support for non-destructive mutation using `with` expressions
+
+### 🧩 Extensible Provider Architecture
+- Interface-based provider system
+- Easy to implement custom data providers
+- Dependency injection-friendly
+- Mock providers for testing
+
+## 📖 Documentation
+
+- **[Complete Documentation](https://github.com/tudormobile/IronLedger/tree/main/docs)** - Comprehensive guides and API reference
+- **[API Documentation](https://github.com/tudormobile/IronLedger/tree/main/docs/api)** - Generated API reference
+
+## 🔧 Requirements
+
+- **.NET 10.0** or higher
+- **Windows OS** designed for windows desktop UI applications
+- **Administrator privileges** recommended for accessing some hardware data
+
+## 🤝 Contributing
+
+Contributions are welcome! Please read our [Contributing Guidelines](https://github.com/tudormobile/IronLedger/blob/main/CONTRIBUTING.md) before submitting pull requests.
+
+## 📄 License
+
+This project is licensed under the MIT License - see the [LICENSE](https://github.com/tudormobile/IronLedger/blob/main/LICENSE) file for details.
+
+## 🔗 Links
+
+- **GitHub Repository:** https://github.com/tudormobile/IronLedger
+- **Issue Tracker:** https://github.com/tudormobile/IronLedger/issues
+- **Documentation:** https://github.com/tudormobile/IronLedger/tree/main/docs
+- **NuGet Package:** https://www.nuget.org/packages/Tudormobile.IronLedgerLib.UI/
+
+## 💡 Use Cases
+
+IronLedgerLib is ideal for:
+
+- **Asset Management Systems** - Track hardware across your infrastructure
+- **License Enforcement** - Hardware-based license validation
+- **IT Inventory** - Automated hardware inventory collection
+- **Configuration Management** - Infrastructure as code with hardware tracking
+- **Audit & Compliance** - Hardware change detection and reporting
+- **Device Registration** - Unique device identification for cloud services
+
+---
+
+**Built with ❤️ by Tudormobile**

--- a/src/IronLedgerLib.UI.Wpf/README.md
+++ b/src/IronLedgerLib.UI.Wpf/README.md
@@ -31,7 +31,7 @@ Perfect for building windows desktop UI applications that leverage the Iron Ledg
 |----------|--------|
 | **Windows** | ✅ Fully Supported |
 | **Linux** | Not supported or planned |
-| **macOS** | Noy supported or planned |
+| **macOS** | Not supported or planned |
 
 
 ## 📦 Installation

--- a/src/IronLedgerLib.UI.Wpf/README.md
+++ b/src/IronLedgerLib.UI.Wpf/README.md
@@ -1,6 +1,6 @@
 # IronLedger
 
-[![NuGet](https://img.shields.io/nuget/v/Tudormobile.IronLedgerLib.UI..Wpf.svg)](https://www.nuget.org/packages/Tudormobile.IronLedgerLib.UI.Wpf/)
+[![NuGet](https://img.shields.io/nuget/v/Tudormobile.IronLedgerLib.UI.Wpf.svg)](https://www.nuget.org/packages/Tudormobile.IronLedgerLib.UI.Wpf/)
 [![License](https://img.shields.io/github/license/tudormobile/IronLedger)](https://github.com/tudormobile/IronLedger/blob/main/LICENSE.txt)
 [![.NET](https://img.shields.io/badge/.NET-10.0-blue.svg)](https://dotnet.microsoft.com/download)
 

--- a/src/IronLedgerLib.UI.Wpf/README.md
+++ b/src/IronLedgerLib.UI.Wpf/README.md
@@ -21,7 +21,7 @@ IronLedgerLib.UI enables applications and services to:
 
 IronLedgerLib.UI.Wpf enables applications and services to:
 - **Views** to display system assets and components on the Windows Desktop platform
-- **Controls** to manage display snd editing of components on Windows desktop
+- **Controls** to manage display and editing of components on Windows desktop
 
 Perfect for building windows desktop UI applications that leverage the Iron Ledger library.
 

--- a/src/IronLedgerLib.UI.Wpf/README.md
+++ b/src/IronLedgerLib.UI.Wpf/README.md
@@ -127,7 +127,7 @@ This project is licensed under the MIT License - see the [LICENSE](https://githu
 - **GitHub Repository:** https://github.com/tudormobile/IronLedger
 - **Issue Tracker:** https://github.com/tudormobile/IronLedger/issues
 - **Documentation:** https://github.com/tudormobile/IronLedger/tree/main/docs
-- **NuGet Package:** https://www.nuget.org/packages/Tudormobile.IronLedgerLib.UI/
+- **NuGet Package:** https://www.nuget.org/packages/Tudormobile.IronLedgerLib.UI.Wpf/
 
 ## 💡 Use Cases
 

--- a/src/IronLedgerLib.UI.Wpf/Views/AssetIdView.xaml
+++ b/src/IronLedgerLib.UI.Wpf/Views/AssetIdView.xaml
@@ -1,0 +1,22 @@
+﻿<UserControl x:Class="Tudormobile.IronLedgerLib.UI.Wpf.Views.AssetIdView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Tudormobile.IronLedgerLib.UI.Wpf.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid RowDefinitions="Auto,Auto">
+        <!-- Top Row, System Metadata (Fixed) -->
+        <local:AssetMetadataView DataContext="{Binding SystemMetadata}" />
+        <!-- Bottom Row, Baseboard/BIOS Metadata (Can Wrap) -->
+        <WrapPanel Grid.Row="1">
+            <GroupBox Header="Motherboard" Margin="4,4,4,0" Padding="2,0">
+                <local:AssetMetadataView DataContext="{Binding BaseBoardMetadata}" />
+            </GroupBox>
+            <GroupBox Header="Bios" Margin="4,4,4,0" Padding="2,0">
+                <local:AssetMetadataView DataContext="{Binding BiosMetadata}" />
+            </GroupBox>
+        </WrapPanel>
+    </Grid>
+</UserControl>

--- a/src/IronLedgerLib.UI.Wpf/Views/AssetIdView.xaml.cs
+++ b/src/IronLedgerLib.UI.Wpf/Views/AssetIdView.xaml.cs
@@ -1,0 +1,18 @@
+﻿
+using System.Windows.Controls;
+
+namespace Tudormobile.IronLedgerLib.UI.Wpf.Views;
+
+/// <summary>
+/// Interaction logic for AssetIdView.xaml
+/// </summary>
+public partial class AssetIdView : UserControl
+{
+    /// <summary>
+    /// Initializes a new instance of the AssetIdView class.
+    /// </summary>
+    public AssetIdView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/IronLedgerLib.UI.Wpf/Views/AssetMetadataView.xaml
+++ b/src/IronLedgerLib.UI.Wpf/Views/AssetMetadataView.xaml
@@ -1,0 +1,26 @@
+﻿<UserControl x:Class="Tudormobile.IronLedgerLib.UI.Wpf.Views.AssetMetadataView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:converter="clr-namespace:Tudormobile.IronLedgerLib.UI.Wpf.Converters"
+             xmlns:local="clr-namespace:Tudormobile.IronLedgerLib.UI.Wpf.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto">
+        <Grid.Resources>
+            <Style TargetType="TextBlock">
+                <Setter Property="Margin" Value="4,0"/>
+            </Style>
+            <converter:VisibilityConverter x:Key="VisibilityConverter"/>
+        </Grid.Resources>
+        <!-- Prompts -->
+        <TextBlock Grid.Row="0" Text="Product:" />
+        <TextBlock Grid.Row="1" Text="Manufacturer:" />
+        <TextBlock Grid.Row="2" Text="Serial No.:" Visibility="{Binding SerialNumber, Converter={StaticResource VisibilityConverter}}" />
+        <!-- Values -->
+        <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding Product}" d:Text="Microsoft Surface Laptop, 7th Edition" />
+        <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Manufacturer}" d:Text="Microsoft Corporation" />
+        <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding SerialNumber}" d:Text="0000-11112222-3333" Visibility="{Binding SerialNumber, Converter={StaticResource VisibilityConverter}}" />
+    </Grid>
+</UserControl>

--- a/src/IronLedgerLib.UI.Wpf/Views/AssetMetadataView.xaml.cs
+++ b/src/IronLedgerLib.UI.Wpf/Views/AssetMetadataView.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System.Windows.Controls;
+
+namespace Tudormobile.IronLedgerLib.UI.Wpf.Views;
+
+/// <summary>
+/// Interaction logic for AssetMetadataView.xaml
+/// </summary>
+public partial class AssetMetadataView : UserControl
+{
+    /// <summary>
+    /// Initializes a new instance of the AssetMetadataView class.
+    /// </summary>
+    public AssetMetadataView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/IronLedgerLib.UI.Wpf/Views/AssetView.xaml
+++ b/src/IronLedgerLib.UI.Wpf/Views/AssetView.xaml
@@ -1,0 +1,119 @@
+﻿<UserControl x:Class="Tudormobile.IronLedgerLib.UI.Wpf.Views.AssetView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Tudormobile.IronLedgerLib.UI.Wpf.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <Grid.Resources>
+            <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+            <DataTemplate x:Key="componentData">
+                <local:ComponentDataView DataContext="{Binding}"/>
+            </DataTemplate>
+        </Grid.Resources>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <TextBox Grid.Row="0" Padding="10,0" 
+                 HorizontalAlignment="Center" HorizontalContentAlignment="Center" 
+                 Text="{Binding System.DisplayName}" 
+                 PreviewKeyDown="TextBox_PreviewKeyDown"
+                 GotKeyboardFocus="TextBox_GotKeyboardFocus"
+                 Margin="10" FontSize="18" FontWeight="SemiBold" BorderBrush="Transparent">
+        </TextBox>
+        <GroupBox Grid.Row="1" Margin="10,0">
+            <GroupBox.Header>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Visibility="{Binding ElementName=Description, Path=IsKeyboardFocused, Converter={StaticResource BooleanToVisibilityConverter}}" FontFamily="Segoe Fluent Icons" Text="&#xE70F;" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                    <TextBlock Text="Description" />
+                </StackPanel>
+            </GroupBox.Header>
+            <TextBox x:Name="Description" 
+                     PreviewKeyDown="TextBox_PreviewKeyDown"
+                     GotKeyboardFocus="TextBox_GotKeyboardFocus"
+                     Text="{Binding System.Description}" 
+                     TextWrapping="Wrap" Height="40" BorderThickness="0" MaxLength="200"/>
+        </GroupBox>
+        <TextBlock Grid.Row="1" Margin="0,0,14,-9" Opacity=".5"
+                   FontStyle="Italic" FontSize="8"
+                   HorizontalAlignment="Right" 
+                   VerticalAlignment="Bottom"
+                   Text="{Binding AssetId.Id}"/>
+        <local:AssetIdView Grid.Row="2" DataContext="{Binding AssetId}" Margin="10"/>
+
+        <TabControl Grid.Row="3" Padding="10,10,0,0">
+            <TabItem Margin="4,0,0,0" >
+                <TabItem.Header>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock FontFamily="Segoe Fluent Icons" Text="&#xE770;" Margin="0,0,5,0" VerticalAlignment="Center"/>
+                        <TextBlock Text="System" Margin="0,0,5,0"/>
+                    </StackPanel>
+                </TabItem.Header>
+                <ItemsControl ItemsSource="{Binding System.Data.Properties}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <local:ComponentPropertyView />
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </TabItem>
+            <TabItem Margin="0">
+                <TabItem.Header>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock FontFamily="Segoe Fluent Icons" Text="&#xE950;" Margin="0,0,5,0" VerticalAlignment="Center"/>
+                        <TextBlock Text="Processors" Margin="0,0,5,0"/>
+                        <TextBlock Text="{Binding Processors.Count, StringFormat='{}({0:N0})'}" Opacity=".6" FontSize="10" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </TabItem.Header>
+                <ScrollViewer Grid.Row="5" CanContentScroll="False" VerticalScrollBarVisibility="Visible">
+                    <ItemsControl ItemsSource="{Binding Processors}" ItemTemplate="{StaticResource componentData}"/>
+                </ScrollViewer>
+            </TabItem>
+            <TabItem Margin="0">
+                <TabItem.Header>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock FontFamily="Segoe Fluent Icons" Text="&#xE964;" Margin="0,0,5,0" VerticalAlignment="Center"/>
+                        <TextBlock Text="Memory" Margin="0,0,5,0"/>
+                        <TextBlock Text="{Binding Memory.Count, StringFormat='{}({0:N0})'}" Opacity=".6" FontSize="10" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </TabItem.Header>
+                <ScrollViewer Grid.Row="5" CanContentScroll="False" VerticalScrollBarVisibility="Visible">
+                    <ItemsControl ItemsSource="{Binding Memory}" ItemTemplate="{StaticResource componentData}"/>
+                </ScrollViewer>
+            </TabItem>
+            <TabItem Margin="0">
+                <TabItem.Header>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock FontFamily="Segoe Fluent Icons" FontSize="16" Text="&#xEDA2;" Margin="0,0,5,0" VerticalAlignment="Center"/>
+                        <TextBlock Text="Disks" Margin="0,0,5,0"/>
+                        <TextBlock Text="{Binding Disks.Count, StringFormat='{}({0:N0})'}" Opacity=".6" FontSize="10" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </TabItem.Header>
+                <ScrollViewer Grid.Row="5" CanContentScroll="False" VerticalScrollBarVisibility="Visible">
+                    <ItemsControl ItemsSource="{Binding Disks}" ItemTemplate="{StaticResource componentData}"/>
+                </ScrollViewer>
+            </TabItem>
+            <TabItem Margin="0">
+                <TabItem.Header>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock FontFamily="Segoe Fluent Icons" Text="&#xF742;" Margin="0,0,5,0" VerticalAlignment="Center"/>
+                        <TextBlock Text="Notes" Margin="0,0,5,0"/>
+                    </StackPanel>
+                </TabItem.Header>
+                <Border SnapsToDevicePixels="True" BorderBrush="{Binding ElementName=NotesTextBox, Path=BorderBrush}" BorderThickness="1" Margin="0,0,10,10" CornerRadius="6" Padding="3">
+                    <TextBox Text="{Binding System.Notes, UpdateSourceTrigger=PropertyChanged}" x:Name="NotesTextBox"
+                             AcceptsReturn="True" BorderThickness="0"
+                             Padding="10" VerticalScrollBarVisibility="Auto"
+                             AcceptsTab="True" TextWrapping="Wrap" MaxLength="1200">
+                    </TextBox>
+                </Border>
+            </TabItem>
+        </TabControl>
+    </Grid>
+</UserControl>

--- a/src/IronLedgerLib.UI.Wpf/Views/AssetView.xaml
+++ b/src/IronLedgerLib.UI.Wpf/Views/AssetView.xaml
@@ -71,7 +71,7 @@
                         <TextBlock Text="{Binding Processors.Count, StringFormat='{}({0:N0})'}" Opacity=".6" FontSize="10" VerticalAlignment="Center"/>
                     </StackPanel>
                 </TabItem.Header>
-                <ScrollViewer Grid.Row="5" CanContentScroll="False" VerticalScrollBarVisibility="Visible">
+                <ScrollViewer CanContentScroll="False" VerticalScrollBarVisibility="Visible">
                     <ItemsControl ItemsSource="{Binding Processors}" ItemTemplate="{StaticResource componentData}"/>
                 </ScrollViewer>
             </TabItem>
@@ -83,7 +83,7 @@
                         <TextBlock Text="{Binding Memory.Count, StringFormat='{}({0:N0})'}" Opacity=".6" FontSize="10" VerticalAlignment="Center"/>
                     </StackPanel>
                 </TabItem.Header>
-                <ScrollViewer Grid.Row="5" CanContentScroll="False" VerticalScrollBarVisibility="Visible">
+                <ScrollViewer CanContentScroll="False" VerticalScrollBarVisibility="Visible">
                     <ItemsControl ItemsSource="{Binding Memory}" ItemTemplate="{StaticResource componentData}"/>
                 </ScrollViewer>
             </TabItem>
@@ -95,7 +95,7 @@
                         <TextBlock Text="{Binding Disks.Count, StringFormat='{}({0:N0})'}" Opacity=".6" FontSize="10" VerticalAlignment="Center"/>
                     </StackPanel>
                 </TabItem.Header>
-                <ScrollViewer Grid.Row="5" CanContentScroll="False" VerticalScrollBarVisibility="Visible">
+                <ScrollViewer CanContentScroll="False" VerticalScrollBarVisibility="Visible">
                     <ItemsControl ItemsSource="{Binding Disks}" ItemTemplate="{StaticResource componentData}"/>
                 </ScrollViewer>
             </TabItem>

--- a/src/IronLedgerLib.UI.Wpf/Views/AssetView.xaml.cs
+++ b/src/IronLedgerLib.UI.Wpf/Views/AssetView.xaml.cs
@@ -1,0 +1,54 @@
+﻿using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace Tudormobile.IronLedgerLib.UI.Wpf.Views;
+
+/// <summary>
+/// Interaction logic for AssetView.xaml
+/// </summary>
+public partial class AssetView : UserControl
+{
+    private readonly Dictionary<TextBox, string> _originalValues = [];
+
+    /// <summary>
+    /// Initializes a new instance of the AssetView class.
+    /// </summary>
+    public AssetView()
+    {
+        InitializeComponent();
+    }
+
+    private void TextBox_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (sender is TextBox textBox)
+        {
+            if (e.Key == Key.Escape)
+            {
+                // Restore original value before clearing focus so bindings see the reverted text.
+                textBox.Text = _originalValues.TryGetValue(textBox, out string? value) ? value : string.Empty;
+                _originalValues.Remove(textBox);
+                Keyboard.ClearFocus();
+                e.Handled = true;
+            }
+            else if (e.Key == Key.Enter)
+            {
+                // If empty, treat as cancel by restoring original text before clearing focus.
+                if (string.IsNullOrEmpty(textBox.Text))
+                {
+                    textBox.Text = _originalValues.TryGetValue(textBox, out string? value) ? value : string.Empty;
+                    _originalValues.Remove(textBox);
+                }
+                Keyboard.ClearFocus();
+                e.Handled = true;
+            }
+        }
+    }
+
+    private void TextBox_GotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+    {
+        if (sender is TextBox textBox && !string.IsNullOrEmpty(textBox.Text))
+        {
+            _originalValues[textBox] = textBox.Text;
+        }
+    }
+}

--- a/src/IronLedgerLib.UI.Wpf/Views/ComponentDataView.xaml
+++ b/src/IronLedgerLib.UI.Wpf/Views/ComponentDataView.xaml
@@ -1,0 +1,21 @@
+﻿<UserControl x:Class="Tudormobile.IronLedgerLib.UI.Wpf.Views.ComponentDataView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Tudormobile.IronLedgerLib.UI.Wpf.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid RowDefinitions="Auto,*">
+        <GroupBox Header="{Binding Caption, FallbackValue='[ caption ]'}" Margin="0,0,10,10">
+            <local:AssetMetadataView DataContext="{Binding Metadata}"/>
+        </GroupBox>
+        <ItemsControl Grid.Row="1" ItemsSource="{Binding Properties}">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <local:ComponentPropertyView DataContext="{Binding}" Margin="10,0,0,0" />
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+    </Grid>
+</UserControl>

--- a/src/IronLedgerLib.UI.Wpf/Views/ComponentDataView.xaml.cs
+++ b/src/IronLedgerLib.UI.Wpf/Views/ComponentDataView.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System.Windows.Controls;
+
+namespace Tudormobile.IronLedgerLib.UI.Wpf.Views;
+
+/// <summary>
+/// Interaction logic for ComponentDataView.xaml
+/// </summary>
+public partial class ComponentDataView : UserControl
+{
+    /// <summary>
+    /// Initializes a new instance of the ComponentDataView class.
+    /// </summary>
+    public ComponentDataView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/IronLedgerLib.UI.Wpf/Views/ComponentPropertyView.xaml
+++ b/src/IronLedgerLib.UI.Wpf/Views/ComponentPropertyView.xaml
@@ -1,0 +1,18 @@
+﻿<UserControl x:Class="Tudormobile.IronLedgerLib.UI.Wpf.Views.ComponentPropertyView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Tudormobile.IronLedgerLib.UI.Wpf.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid ColumnDefinitions="Auto,*">
+        <Grid.Resources>
+            <Style TargetType="TextBlock">
+                <Setter Property="Margin" Value="4,0"/>
+            </Style>
+        </Grid.Resources>
+        <TextBlock Grid.Column="0" Text="{Binding Name, StringFormat='{}{0}:'}" d:Text="[ name ]:" Margin="0,0,4,0"/>
+        <TextBlock Grid.Column="1" Text="{Binding Value}" d:Text="[ value ]" FontWeight="SemiBold"/>
+    </Grid>
+</UserControl>

--- a/src/IronLedgerLib.UI.Wpf/Views/ComponentPropertyView.xaml.cs
+++ b/src/IronLedgerLib.UI.Wpf/Views/ComponentPropertyView.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System.Windows.Controls;
+
+namespace Tudormobile.IronLedgerLib.UI.Wpf.Views;
+
+/// <summary>
+/// Interaction logic for ComponentPropertyView.xaml
+/// </summary>
+public partial class ComponentPropertyView : UserControl
+{
+    /// <summary>
+    /// Initializes a new instance of the ComponentPropertyView class.
+    /// </summary>
+    public ComponentPropertyView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
Closes #27

Introduces IronLedgerLib.UI.Wpf, a new .NET 10.0 WPF UI library with reusable user controls for asset and component display/editing. Adds a robust VisibilityConverter with full unit test coverage. Updates solution and sample app dependencies to use latest UI/Services packages. Includes documentation and changelog updates for v0.5.0.