### PR TITLE
Add notes and components API support to client and service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Planned
-- Improve documentation
+- Asset sanitation and disposal endpoints
+- Integration tests
 
-## [0.5.0] - 
+## [0.5.0] - 2026-03-24
 
 ### Added
 - Refined the public interface
 - Moved some UI elements from Wpf sample app into a new UI library for Wpf
 - Updated package references in sample applications
+- Improved documentation
+- Added notes api to the client
+- Added components api to the client
 
 ## [0.4.0] - 2026-03-22
 

--- a/docs/api/Tudormobile.md
+++ b/docs/api/Tudormobile.md
@@ -7,6 +7,7 @@ using Tudormobile.IronLedgerLib;
 
 using Tudormobile.IronLedgerLib.Services;
 using Tudormobile.IronLedgerLib.UI;
+using Tudormobile.IronLedgerLib.UI.Wpf;
 ```
 
 - [Tudormobile.IronLedgerLib](Tudormobile.IronLedgerLib.yml)
@@ -15,6 +16,8 @@ using Tudormobile.IronLedgerLib.UI;
     - Web services.
 - [Tudormobile.IronLedgerLib.UI](Tudormobile.IronLedgerLib.UI.yml)
     - UI elements.
+- [Tudormobile.IronLedgerLib.UI.Wpf](Tudormobile.IronLedgerLib.UI.Wpf.yml)
+    - Windows desktop UI elements.
 
 Latest unit testing results are shown below.
 [!include[summary](../../src/output/SummaryGithub.md)]

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -7,6 +7,7 @@
           "files": [
             "**/IronLedgerLib/bin/Release/net10.0/Tudormobile*.dll",
             "**/IronLedgerLib.UI/bin/Release/net10.0/Tudormobile*.UI.dll",
+            "**/IronLedgerLib.UI/bin/Release/net10.0/Tudormobile*.UI.Wpf.dll",
             "**/IronLedgerLib.Services/bin/Release/net10.0/Tudormobile*.Services.dll"
           ],
           "exclude": [

--- a/docs/exception-handling.md
+++ b/docs/exception-handling.md
@@ -289,7 +289,7 @@ Is it a programming error (null argument, invalid state)?
 2. ✅ **DO** use `ArgumentException` for invalid parameter values
 3. ✅ **DO** use `ComponentDataProviderException` for provider failures
 4. ✅ **DO** include the original exception as `InnerException` when wrapping
-5. ✅ **DO** populate `ProviderName` and `WmiClassName` in provider exceptions
+5. ✅ **DO** populate `ProviderName` in provider exceptions
 6. ✅ **DO** document all exceptions in XML comments
 7. ✅ **DO** write tests for exception scenarios
 8. ❌ **DON'T** catch exceptions you can't handle meaningfully

--- a/src/IronLedgerLib.Services.Tests/IronLedgerClientTests.cs
+++ b/src/IronLedgerLib.Services.Tests/IronLedgerClientTests.cs
@@ -456,6 +456,347 @@ public class IronLedgerClientTests
         Assert.AreEqual("Response contained no data.", result.ErrorMessage);
     }
 
+    // --- GetNotesAsync ---
+
+    [TestMethod]
+    public async Task GetNotesAsync_WithNullAssetId_Throws()
+    {
+        using var httpClient = new HttpClient(new MockHttpMessageHandler()) { BaseAddress = new Uri("http://www.example.com/") };
+        var client = new IronLedgerClient(httpClient);
+
+        var exception = await Assert.ThrowsExactlyAsync<ArgumentNullException>(() => client.GetNotesAsync(null!, TestContext.CancellationToken));
+
+        Assert.Contains("assetIdString", exception.Message);
+    }
+
+    [TestMethod]
+    public async Task GetNotesAsync_WithEmptyAssetId_Throws()
+    {
+        using var httpClient = new HttpClient(new MockHttpMessageHandler()) { BaseAddress = new Uri("http://www.example.com/") };
+        var client = new IronLedgerClient(httpClient);
+
+        var exception = await Assert.ThrowsExactlyAsync<ArgumentException>(() => client.GetNotesAsync(string.Empty, TestContext.CancellationToken));
+
+        Assert.Contains("assetIdString", exception.Message);
+    }
+
+    [TestMethod]
+    public async Task GetNotesAsync_RequestsCorrectEndpoint()
+    {
+        var handler = new MockHttpMessageHandler() { JsonResponse = "some notes" };
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://myserver:5037/") };
+        var client = new IronLedgerClient(httpClient);
+
+        await client.GetNotesAsync("my-asset-id", TestContext.CancellationToken);
+
+        Assert.AreEqual("https://myserver:5037/api/v1/assets/my-asset-id/notes", handler.ProvidedRequestUri!.ToString());
+    }
+
+    [TestMethod]
+    public async Task GetNotesAsync_OnSuccess_ReturnsNotes()
+    {
+        const string notes = "these are the asset notes";
+        var handler = new MockHttpMessageHandler() { JsonResponse = notes };
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://myserver:5037/") };
+        var client = new IronLedgerClient(httpClient);
+
+        var result = await client.GetNotesAsync("my-asset-id", TestContext.CancellationToken);
+
+        Assert.IsTrue(result.IsSuccess);
+        Assert.AreEqual(notes, result.Data);
+    }
+
+    [TestMethod]
+    public async Task GetNotesAsync_OnHttpError_ReturnsFailure()
+    {
+        var handler = new MockHttpMessageHandler() { AlwaysResponds = new HttpResponseMessage(HttpStatusCode.InternalServerError) };
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://myserver:5037/") };
+        var client = new IronLedgerClient(httpClient);
+
+        var result = await client.GetNotesAsync("my-asset-id", TestContext.CancellationToken);
+
+        Assert.IsFalse(result.IsSuccess);
+        Assert.IsNotNull(result.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task GetNotesAsync_ByAssetId_RequestsCorrectEndpoint()
+    {
+        var assetId = new AssetId() { BaseBoardMetadata = AssetMetadata.Empty, BiosMetadata = AssetMetadata.Empty, SystemMetadata = AssetMetadata.Empty };
+        var handler = new MockHttpMessageHandler() { JsonResponse = "some notes" };
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://myserver:5037/") };
+        var client = IIronLedgerClient.Create(httpClient);
+
+        var result = await client.GetNotesAsync(assetId, TestContext.CancellationToken);
+
+        Assert.IsTrue(result.IsSuccess);
+        Assert.AreEqual($"https://myserver:5037/api/v1/assets/{assetId.Id}/notes", handler.ProvidedRequestUri!.ToString());
+    }
+
+    // --- SetNotesAsync ---
+
+    [TestMethod]
+    public async Task SetNotesAsync_WithNullAssetId_Throws()
+    {
+        using var httpClient = new HttpClient(new MockHttpMessageHandler()) { BaseAddress = new Uri("http://www.example.com/") };
+        var client = new IronLedgerClient(httpClient);
+
+        await Assert.ThrowsExactlyAsync<ArgumentNullException>(() => client.SetNotesAsync(null!, "notes", TestContext.CancellationToken));
+    }
+
+    [TestMethod]
+    public async Task SetNotesAsync_RequestsCorrectEndpoint()
+    {
+        const string assetIdString = "my-asset-id";
+        var handler = new MockHttpMessageHandler() { JsonResponse = $"\"{assetIdString}\"" };
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://myserver:5037/") };
+        var client = new IronLedgerClient(httpClient);
+
+        await client.SetNotesAsync(assetIdString, "notes", TestContext.CancellationToken);
+
+        Assert.AreEqual($"https://myserver:5037/api/v1/assets/{assetIdString}/notes", handler.ProvidedRequestUri!.ToString());
+    }
+
+    [TestMethod]
+    public async Task SetNotesAsync_OnMatchingResponse_ReturnsSuccess()
+    {
+        const string assetIdString = "my-asset-id";
+        var handler = new MockHttpMessageHandler() { JsonResponse = $"\"{assetIdString}\"" };
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://myserver:5037/") };
+        var client = new IronLedgerClient(httpClient);
+
+        var result = await client.SetNotesAsync(assetIdString, "these are notes", TestContext.CancellationToken);
+
+        Assert.IsTrue(result.IsSuccess);
+        Assert.AreEqual(assetIdString, result.Data);
+    }
+
+    [TestMethod]
+    public async Task SetNotesAsync_WithFullAssetId_OnMatchingResponse_ReturnsSuccess()
+    {
+        var assetId = new AssetId()
+        {
+            BaseBoardMetadata = AssetMetadata.Empty,
+            BiosMetadata = AssetMetadata.Empty,
+            SystemMetadata = AssetMetadata.Empty,
+        };
+        var assetIdString = assetId.Id;
+
+        var handler = new MockHttpMessageHandler() { JsonResponse = $"\"{assetIdString}\"" };
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://myserver:5037/") };
+        var client = IIronLedgerClient.Create(httpClient);
+
+        var result = await client.SetNotesAsync(assetId, "these are notes", TestContext.CancellationToken);
+
+        Assert.IsTrue(result.IsSuccess);
+        Assert.AreEqual(assetIdString, result.Data);
+
+    }
+
+    [TestMethod]
+    public async Task SetNotesAsync_OnMismatchedResponse_ReturnsFailure()
+    {
+        var handler = new MockHttpMessageHandler() { JsonResponse = "\"different-id\"" };
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://myserver:5037/") };
+        var client = new IronLedgerClient(httpClient);
+
+        var result = await client.SetNotesAsync("my-asset-id", "notes", TestContext.CancellationToken);
+
+        Assert.IsFalse(result.IsSuccess);
+        Assert.IsNotNull(result.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task SetNotesAsync_OnHttpError_ReturnsFailure()
+    {
+        var handler = new MockHttpMessageHandler() { AlwaysResponds = new HttpResponseMessage(HttpStatusCode.InternalServerError) };
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://myserver:5037/") };
+        var client = new IronLedgerClient(httpClient);
+
+        var result = await client.SetNotesAsync("my-asset-id", "notes", TestContext.CancellationToken);
+
+        Assert.IsFalse(result.IsSuccess);
+        Assert.IsNotNull(result.ErrorMessage);
+    }
+
+    // --- GetComponentsAsync ---
+
+    [TestMethod]
+    public async Task GetComponentsAsync_WithNullAssetId_Throws()
+    {
+        using var httpClient = new HttpClient(new MockHttpMessageHandler()) { BaseAddress = new Uri("http://www.example.com/") };
+        var client = new IronLedgerClient(httpClient);
+
+        var exception = await Assert.ThrowsExactlyAsync<ArgumentNullException>(() => client.GetComponentsAsync(null!, TestContext.CancellationToken));
+
+        Assert.Contains("assetIdString", exception.Message);
+    }
+
+    [TestMethod]
+    public async Task GetComponentsAsync_WithEmptyAssetId_Throws()
+    {
+        using var httpClient = new HttpClient(new MockHttpMessageHandler()) { BaseAddress = new Uri("http://www.example.com/") };
+        var client = new IronLedgerClient(httpClient);
+
+        var exception = await Assert.ThrowsExactlyAsync<ArgumentException>(() => client.GetComponentsAsync(string.Empty, TestContext.CancellationToken));
+
+        Assert.Contains("assetIdString", exception.Message);
+    }
+
+    [TestMethod]
+    public async Task GetComponentsAsync_RequestsCorrectEndpoint()
+    {
+        var handler = new MockHttpMessageHandler() { JsonResponse = @"{""system"":{""metadata"":{""serial_number"":"""",""manufacturer"":"""",""product"":""""},""caption"":"""",""properties"":{}},""processors"":[],""memory"":[],""disks"":[]}" };
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://myserver:5037/") };
+        var client = new IronLedgerClient(httpClient);
+
+        await client.GetComponentsAsync("my-asset-id", TestContext.CancellationToken);
+
+        Assert.AreEqual("https://myserver:5037/api/v1/assets/my-asset-id/components", handler.ProvidedRequestUri!.ToString());
+    }
+
+    [TestMethod]
+    public async Task GetComponentsAsync_OnSuccess_ReturnsComponentData()
+    {
+        var handler = new MockHttpMessageHandler() { JsonResponse = @"{""system"":{""metadata"":{""serial_number"":"""",""manufacturer"":"""",""product"":""""},""caption"":"""",""properties"":{}},""processors"":[],""memory"":[],""disks"":[]}" };
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://myserver:5037/") };
+        var client = new IronLedgerClient(httpClient);
+
+        var result = await client.GetComponentsAsync("my-asset-id", TestContext.CancellationToken);
+
+        Assert.IsTrue(result.IsSuccess);
+        Assert.IsNotNull(result.Data);
+        Assert.IsNotNull(result.Data.System);
+        Assert.HasCount(0, result.Data.Processors);
+        Assert.HasCount(0, result.Data.Memory);
+        Assert.HasCount(0, result.Data.Disks);
+    }
+
+    [TestMethod]
+    public async Task GetComponentsAsync_WithFullAssetId_PassesId()
+    {
+        var handler = new MockHttpMessageHandler() { JsonResponse = @"{""system"":{""metadata"":{""serial_number"":"""",""manufacturer"":"""",""product"":""""},""caption"":"""",""properties"":{}},""processors"":[],""memory"":[],""disks"":[]}" };
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://myserver:5037/") };
+        var assetId = new AssetId()
+        {
+            BaseBoardMetadata = AssetMetadata.Empty,
+            BiosMetadata = AssetMetadata.Empty,
+            SystemMetadata = AssetMetadata.Empty,
+        };
+        var id = assetId.Id;
+        var client = IIronLedgerClient.Create(httpClient);
+
+        var result = await client.GetComponentsAsync(assetId, TestContext.CancellationToken);
+
+        Assert.Contains(id, handler.ProvidedRequestUri!.ToString());
+    }
+
+
+
+    [TestMethod]
+    public async Task GetComponentsAsync_OnHttpError_ReturnsFailure()
+    {
+        var handler = new MockHttpMessageHandler() { AlwaysResponds = new HttpResponseMessage(HttpStatusCode.InternalServerError) };
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://myserver:5037/") };
+        var client = new IronLedgerClient(httpClient);
+
+        var result = await client.GetComponentsAsync("my-asset-id", TestContext.CancellationToken);
+
+        Assert.IsFalse(result.IsSuccess);
+        Assert.IsNotNull(result.ErrorMessage);
+    }
+
+    // --- SetComponentsAsync ---
+
+    [TestMethod]
+    public async Task SetComponentsAsync_WithNullAssetId_Throws()
+    {
+        using var httpClient = new HttpClient(new MockHttpMessageHandler()) { BaseAddress = new Uri("http://www.example.com/") };
+        var client = new IronLedgerClient(httpClient);
+        var components = new SystemComponentData { System = ComponentData.Empty, Processors = [], Memory = [], Disks = [] };
+
+        await Assert.ThrowsExactlyAsync<ArgumentNullException>(() => client.SetComponentsAsync(null!, components, TestContext.CancellationToken));
+    }
+
+    [TestMethod]
+    public async Task SetComponentsAsync_RequestsCorrectEndpoint()
+    {
+        const string assetIdString = "my-asset-id";
+        var handler = new MockHttpMessageHandler() { JsonResponse = $"\"{assetIdString}\"" };
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://myserver:5037/") };
+        var client = new IronLedgerClient(httpClient);
+        var components = new SystemComponentData { System = ComponentData.Empty, Processors = [], Memory = [], Disks = [] };
+
+        await client.SetComponentsAsync(assetIdString, components, TestContext.CancellationToken);
+
+        Assert.AreEqual($"https://myserver:5037/api/v1/assets/{assetIdString}/components", handler.ProvidedRequestUri!.ToString());
+    }
+
+    [TestMethod]
+    public async Task SetComponentsAsync_WithFullAssetId_RequestsCorrectEndpoint()
+    {
+        var assetId = new AssetId()
+        {
+            BaseBoardMetadata = AssetMetadata.Empty,
+            BiosMetadata = AssetMetadata.Empty,
+            SystemMetadata = AssetMetadata.Empty,
+        };
+        var id = assetId.Id;
+
+        var handler = new MockHttpMessageHandler() { JsonResponse = $"\"{id}\"" };
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://myserver:5037/") };
+        var client = IIronLedgerClient.Create(httpClient);
+        var components = new SystemComponentData { System = ComponentData.Empty, Processors = [], Memory = [], Disks = [] };
+
+        await client.SetComponentsAsync(assetId, components, TestContext.CancellationToken);
+
+        Assert.AreEqual($"https://myserver:5037/api/v1/assets/{id}/components", handler.ProvidedRequestUri!.ToString());
+
+    }
+
+    [TestMethod]
+    public async Task SetComponentsAsync_OnMatchingResponse_ReturnsSuccess()
+    {
+        const string assetIdString = "my-asset-id";
+        var handler = new MockHttpMessageHandler() { JsonResponse = $"\"{assetIdString}\"" };
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://myserver:5037/") };
+        var client = new IronLedgerClient(httpClient);
+        var components = new SystemComponentData { System = ComponentData.Empty, Processors = [], Memory = [], Disks = [] };
+
+        var result = await client.SetComponentsAsync(assetIdString, components, TestContext.CancellationToken);
+
+        Assert.IsTrue(result.IsSuccess);
+        Assert.AreEqual(assetIdString, result.Data);
+    }
+
+    [TestMethod]
+    public async Task SetComponentsAsync_OnMismatchedResponse_ReturnsFailure()
+    {
+        var handler = new MockHttpMessageHandler() { JsonResponse = "\"different-id\"" };
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://myserver:5037/") };
+        var client = new IronLedgerClient(httpClient);
+        var components = new SystemComponentData { System = ComponentData.Empty, Processors = [], Memory = [], Disks = [] };
+
+        var result = await client.SetComponentsAsync("my-asset-id", components, TestContext.CancellationToken);
+
+        Assert.IsFalse(result.IsSuccess);
+        Assert.IsNotNull(result.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task SetComponentsAsync_OnHttpError_ReturnsFailure()
+    {
+        var handler = new MockHttpMessageHandler() { AlwaysResponds = new HttpResponseMessage(HttpStatusCode.InternalServerError) };
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://myserver:5037/") };
+        var client = new IronLedgerClient(httpClient);
+        var components = new SystemComponentData { System = ComponentData.Empty, Processors = [], Memory = [], Disks = [] };
+
+        var result = await client.SetComponentsAsync("my-asset-id", components, TestContext.CancellationToken);
+
+        Assert.IsFalse(result.IsSuccess);
+        Assert.IsNotNull(result.ErrorMessage);
+    }
+
     // --- helpers ---
 
     private sealed class FakeHandler(string content, HttpStatusCode status) : HttpMessageHandler

--- a/src/IronLedgerLib.Services.Tests/IronLedgerClientTests.cs
+++ b/src/IronLedgerLib.Services.Tests/IronLedgerClientTests.cs
@@ -483,7 +483,7 @@ public class IronLedgerClientTests
     [TestMethod]
     public async Task GetNotesAsync_RequestsCorrectEndpoint()
     {
-        var handler = new MockHttpMessageHandler() { JsonResponse = "some notes" };
+        var handler = new MockHttpMessageHandler() { JsonResponse = "\"some notes\"" };
         using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://myserver:5037/") };
         var client = new IronLedgerClient(httpClient);
 
@@ -495,7 +495,7 @@ public class IronLedgerClientTests
     [TestMethod]
     public async Task GetNotesAsync_OnSuccess_ReturnsNotes()
     {
-        const string notes = "these are the asset notes";
+        const string notes = "\"these are the asset notes\"";
         var handler = new MockHttpMessageHandler() { JsonResponse = notes };
         using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://myserver:5037/") };
         var client = new IronLedgerClient(httpClient);

--- a/src/IronLedgerLib.Services/IIronLedgerClient.cs
+++ b/src/IronLedgerLib.Services/IIronLedgerClient.cs
@@ -62,19 +62,19 @@ public interface IIronLedgerClient
     /// <summary>
     /// Asynchronously retrieves the components associated with the specified asset.
     /// </summary>
-    /// <param name="assetIdString">The unique identifier of the asset for which to retrieve notes. Cannot be null or empty.</param>
+    /// <param name="assetIdString">The unique identifier of the asset for which to retrieve components. Cannot be null or empty.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
-    /// <returns>A task that represents the asynchronous operation. The task result contains an IronLedgerResponse with the components
-    /// returns as SystemComponentData.</returns>
+    /// <returns>A task that represents the asynchronous operation. The task result contains an IronLedgerResponse with the
+    /// components returned as SystemComponentData.</returns>
     Task<IronLedgerResponse<SystemComponentData>> GetComponentsAsync(string assetIdString, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Asynchronously retrieves the components associated with the specified asset.
     /// </summary>
-    /// <param name="assetId">The identifier of the asset for which to retrieve notes.</param>
+    /// <param name="assetId">The identifier of the asset for which to retrieve components.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
-    /// <returns>A task that represents the asynchronous operation. The task result contains an IronLedgerResponse with the components
-    /// returns as SystemComponentData.</returns>
+    /// <returns>A task that represents the asynchronous operation. The task result contains an IronLedgerResponse with the
+    /// components returned as SystemComponentData.</returns>
     Task<IronLedgerResponse<SystemComponentData>> GetComponentsAsync(AssetId assetId, CancellationToken cancellationToken = default) => GetComponentsAsync(assetId.Id, cancellationToken);
 
     /// <summary>

--- a/src/IronLedgerLib.Services/IIronLedgerClient.cs
+++ b/src/IronLedgerLib.Services/IIronLedgerClient.cs
@@ -78,9 +78,9 @@ public interface IIronLedgerClient
     Task<IronLedgerResponse<SystemComponentData>> GetComponentsAsync(AssetId assetId, CancellationToken cancellationToken = default) => GetComponentsAsync(assetId.Id, cancellationToken);
 
     /// <summary>
-    /// Asynchronously sets the notes for the specified asset.
+    /// Asynchronously sets the components for the specified asset.
     /// </summary>
-    /// <param name="assetIdString">The unique identifier of the asset for which to set notes. Cannot be null or empty.</param>
+    /// <param name="assetIdString">The unique identifier of the asset for which to set components. Cannot be null or empty.</param>
     /// <param name="components">The components to associate with the asset.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains an IronLedgerResponse with the
@@ -88,9 +88,9 @@ public interface IIronLedgerClient
     Task<IronLedgerResponse<string>> SetComponentsAsync(string assetIdString, SystemComponentData components, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Asynchronously sets the notes for the specified asset.
+    /// Asynchronously sets the components for the specified asset.
     /// </summary>
-    /// <param name="assetId">The identifier of the asset for which to set notes. Cannot be null or empty.</param>
+    /// <param name="assetId">The identifier of the asset for which to set components. Cannot be null or empty.</param>
     /// <param name="components">The notes to associate with the asset.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains an IronLedgerResponse with the

--- a/src/IronLedgerLib.Services/IIronLedgerClient.cs
+++ b/src/IronLedgerLib.Services/IIronLedgerClient.cs
@@ -59,4 +59,80 @@ public interface IIronLedgerClient
     /// asset IDs. The list will be empty if no assets are found.</returns>
     Task<IronLedgerResponse<List<string>>> GetAssetIdsAsync(CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Asynchronously retrieves the components associated with the specified asset.
+    /// </summary>
+    /// <param name="assetIdString">The unique identifier of the asset for which to retrieve notes. Cannot be null or empty.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains an IronLedgerResponse with the components
+    /// returns as SystemComponentData.</returns>
+    Task<IronLedgerResponse<SystemComponentData>> GetComponentsAsync(string assetIdString, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously retrieves the components associated with the specified asset.
+    /// </summary>
+    /// <param name="assetId">The identifier of the asset for which to retrieve notes.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains an IronLedgerResponse with the components
+    /// returns as SystemComponentData.</returns>
+    Task<IronLedgerResponse<SystemComponentData>> GetComponentsAsync(AssetId assetId, CancellationToken cancellationToken = default) => GetComponentsAsync(assetId.Id, cancellationToken);
+
+    /// <summary>
+    /// Asynchronously sets the notes for the specified asset.
+    /// </summary>
+    /// <param name="assetIdString">The unique identifier of the asset for which to set notes. Cannot be null or empty.</param>
+    /// <param name="components">The components to associate with the asset.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains an IronLedgerResponse with the
+    /// string identifier of the updated asset.</returns>
+    Task<IronLedgerResponse<string>> SetComponentsAsync(string assetIdString, SystemComponentData components, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously sets the notes for the specified asset.
+    /// </summary>
+    /// <param name="assetId">The identifier of the asset for which to set notes. Cannot be null or empty.</param>
+    /// <param name="components">The notes to associate with the asset.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains an IronLedgerResponse with the
+    /// string identifier of the updated asset.</returns>
+    Task<IronLedgerResponse<string>> SetComponentsAsync(AssetId assetId, SystemComponentData components, CancellationToken cancellationToken = default) => SetComponentsAsync(assetId.Id, components, cancellationToken);
+
+    /// <summary>
+    /// Asynchronously retrieves the notes associated with the specified asset.
+    /// </summary>
+    /// <param name="assetIdString">The unique identifier of the asset for which to retrieve notes. Cannot be null or empty.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains an IronLedgerResponse with the notes
+    /// as a string. If no notes are found, the response may contain an empty string.</returns>
+    Task<IronLedgerResponse<string>> GetNotesAsync(string assetIdString, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously retrieves the notes associated with the specified asset.
+    /// </summary>
+    /// <param name="assetId">The identifier of the asset for which to retrieve notes.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains an IronLedgerResponse with the notes
+    /// for the specified asset as a string.</returns>
+    Task<IronLedgerResponse<string>> GetNotesAsync(AssetId assetId, CancellationToken cancellationToken = default) => GetNotesAsync(assetId.Id, cancellationToken);
+
+    /// <summary>
+    /// Asynchronously sets the notes for the specified asset.
+    /// </summary>
+    /// <param name="assetIdString">The unique identifier of the asset for which to set notes. Cannot be null or empty.</param>
+    /// <param name="notes">The notes to associate with the asset. May be an empty string to clear existing notes.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains an IronLedgerResponse with the
+    /// string identifier of the updated asset.</returns>
+    Task<IronLedgerResponse<string>> SetNotesAsync(string assetIdString, string notes, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously sets the notes for the specified asset.
+    /// </summary>
+    /// <param name="assetId">The identifier of the asset for which to set notes. Cannot be null or empty.</param>
+    /// <param name="notes">The notes to associate with the asset. May be an empty string to clear existing notes.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains an IronLedgerResponse with the
+    /// string identifier of the updated asset.</returns>
+    Task<IronLedgerResponse<string>> SetNotesAsync(AssetId assetId, string notes, CancellationToken cancellationToken = default) => SetNotesAsync(assetId.Id, notes, cancellationToken);
+
 }

--- a/src/IronLedgerLib.Services/IronLedgerClient.cs
+++ b/src/IronLedgerLib.Services/IronLedgerClient.cs
@@ -130,7 +130,7 @@ internal class IronLedgerClient : IIronLedgerClient
     public Task<IronLedgerResponse<string>> SetNotesAsync(string assetIdString, string notes, CancellationToken cancellationToken = default)
     {
         LogRequest();
-        ArgumentNullException.ThrowIfNull(assetIdString, nameof(assetIdString));
+        ArgumentNullException.ThrowIfNullOrEmpty(assetIdString, nameof(assetIdString));
         return ExecuteAsync<string>(
             ct =>
             {

--- a/src/IronLedgerLib.Services/IronLedgerClient.cs
+++ b/src/IronLedgerLib.Services/IronLedgerClient.cs
@@ -107,7 +107,7 @@ internal class IronLedgerClient : IIronLedgerClient
                 var content = new StringContent(_serializer.Serialize(components), new MediaTypeHeaderValue(_serializer.ContentType));
                 return _httpClient.PatchAsync($"api/v1/assets/{assetIdString}/components", content, ct);
             },
-            nameof(SetNotesAsync),
+            nameof(SetComponentsAsync),
             cancellationToken,
             validate: returnedId => returnedId == assetIdString
                 ? IronLedgerResponse<string>.Success(assetIdString)

--- a/src/IronLedgerLib.Services/IronLedgerClient.cs
+++ b/src/IronLedgerLib.Services/IronLedgerClient.cs
@@ -85,6 +85,65 @@ internal class IronLedgerClient : IIronLedgerClient
             deserialize: body => body);
     }
 
+    /// <inheritdoc/>
+    public Task<IronLedgerResponse<SystemComponentData>> GetComponentsAsync(string assetIdString, CancellationToken cancellationToken = default)
+    {
+        LogRequest();
+        ArgumentNullException.ThrowIfNullOrEmpty(assetIdString, nameof(assetIdString));
+        return ExecuteAsync<SystemComponentData>(
+           ct => _httpClient.GetAsync($"api/v1/assets/{assetIdString}/components", ct),
+           nameof(GetComponentsAsync),
+           cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public Task<IronLedgerResponse<string>> SetComponentsAsync(string assetIdString, SystemComponentData components, CancellationToken cancellationToken = default)
+    {
+        LogRequest();
+        ArgumentNullException.ThrowIfNull(assetIdString, nameof(assetIdString));
+        return ExecuteAsync<string>(
+            ct =>
+            {
+                var content = new StringContent(_serializer.Serialize(components), new MediaTypeHeaderValue(_serializer.ContentType));
+                return _httpClient.PatchAsync($"api/v1/assets/{assetIdString}/components", content, ct);
+            },
+            nameof(SetNotesAsync),
+            cancellationToken,
+            validate: returnedId => returnedId == assetIdString
+                ? IronLedgerResponse<string>.Success(assetIdString)
+                : IronLedgerResponse<string>.Failure($"Response ID '{returnedId}' does not match expected '{assetIdString}'."));
+    }
+
+    /// <inheritdoc/>
+    public Task<IronLedgerResponse<string>> GetNotesAsync(string assetIdString, CancellationToken cancellationToken = default)
+    {
+        LogRequest();
+        ArgumentNullException.ThrowIfNullOrEmpty(assetIdString, nameof(assetIdString));
+        return ExecuteAsync<string>(
+           ct => _httpClient.GetAsync($"api/v1/assets/{assetIdString}/notes", ct),
+           nameof(GetNotesAsync),
+           cancellationToken,
+           deserialize: body => body);
+    }
+
+    /// <inheritdoc/>
+    public Task<IronLedgerResponse<string>> SetNotesAsync(string assetIdString, string notes, CancellationToken cancellationToken = default)
+    {
+        LogRequest();
+        ArgumentNullException.ThrowIfNull(assetIdString, nameof(assetIdString));
+        return ExecuteAsync<string>(
+            ct =>
+            {
+                var content = new StringContent(notes);
+                return _httpClient.PatchAsync($"api/v1/assets/{assetIdString}/notes", content, ct);
+            },
+            nameof(SetNotesAsync),
+            cancellationToken,
+            validate: returnedId => returnedId == assetIdString
+                ? IronLedgerResponse<string>.Success(assetIdString)
+                : IronLedgerResponse<string>.Failure($"Response ID '{returnedId}' does not match expected '{assetIdString}'."));
+    }
+
     private void LogRequest([CallerMemberName] string callerName = "")
     {
         if (!_logger.IsEnabled(LogLevel.Information))

--- a/src/IronLedgerLib.Services/IronLedgerLib.Services.http
+++ b/src/IronLedgerLib.Services/IronLedgerLib.Services.http
@@ -12,17 +12,24 @@ Accept: application/json
 
 ###
 
-# Assets with no AssetId should return list if asset IDs
+# Assets with no AssetId should return list of asset IDs
 GET {{IronLedgerLib.Services_HostAddress}}/api/v1/assets
 Accept: application/json
 
 ###
 
-# Asset with specific Id should return 200-Ok with full Asset OR 404-NotFound
+# Asset with invalid specific Id should return 400 Bad Request
 GET {{IronLedgerLib.Services_HostAddress}}/api/v1/assets/12345
 Accept: application/json
 
 ###
+
+# Asset with specific Id should return 200-Ok with full Asset OR 404-NotFound (this one is 404 Not Found)
+GET {{IronLedgerLib.Services_HostAddress}}/api/v1/assets/000029f573a1758c8ec462e75d0234a30c46c9f8a99359d4c75cfb2a7f0ce4f7
+Accept: application/json
+
+###
+
 
 # Asset with specific Id should return 200-Ok with full Asset OR 404-NotFound
 GET {{IronLedgerLib.Services_HostAddress}}/api/v1/assets/68e129f573a1758c8ec462e75d0234a30c46c9f8a99359d4c75cfb2a7f0ce4f7
@@ -30,7 +37,7 @@ Accept: application/json
 
 ###
 
-# Post a new asset should return 200-Ok OR xxx-Duplicate asset
+# Post a new asset should return 200-Ok OR 409-Conflict
 POST {{IronLedgerLib.Services_HostAddress}}/api/v1/assets/ingest
 Accept: application/json
 Content-Type: application/json
@@ -53,4 +60,47 @@ Content-Type: application/json
   },
   "id": "68e129f573a1758c8ec462e75d0234a30c46c9f8a99359d4c75cfb2a7f0ce4f7"
 }
+###
+
+# Get Components for a asset should return 200 Ok, 400 Bad Request, OR 404 Not Found
+GET {{IronLedgerLib.Services_HostAddress}}/api/v1/assets/68e129f573a1758c8ec462e75d0234a30c46c9f8a99359d4c75cfb2a7f0ce4f7/components
+Accept: application/json
+Content-Type: application/json
+
+###
+
+# Patch components for a asset should return 200 Ok, 400 Bad Request, OR 404 Not Found
+PATCH {{IronLedgerLib.Services_HostAddress}}/api/v1/assets/68e129f573a1758c8ec462e75d0234a30c46c9f8a99359d4c75cfb2a7f0ce4f7/components
+Accept: application/json
+Content-Type: application/json
+
+{
+  "system": {
+    "metadata": {
+      "serial_number": "12345",
+      "manufacturer": "",
+      "product": ""
+    },
+    "caption": "",
+    "properties": {}
+  },
+  "processors": [],
+  "memory": [],
+  "disks": []
+}
+
+###
+# Get Notes for a asset should return 200 Ok, 400 Bad Request, OR 404 Not Found
+GET {{IronLedgerLib.Services_HostAddress}}/api/v1/assets/68e129f573a1758c8ec462e75d0234a30c46c9f8a99359d4c75cfb2a7f0ce4f7/notes
+Accept: application/json
+Content-Type: application/json
+
+###
+
+# Patch Notes for a asset should return 200 Ok, 400 Bad Request, OR 404 Not Found
+PATCH {{IronLedgerLib.Services_HostAddress}}/api/v1/assets/68e129f573a1758c8ec462e75d0234a30c46c9f8a99359d4c75cfb2a7f0ce4f7/notes
+Accept: application/json
+Content-Type: application/json
+
+This is a test, this is only a test. Do not pass go, an do not collect $200.
 ###

--- a/src/IronLedgerLib.Services/IronLedgerLib.Services.http
+++ b/src/IronLedgerLib.Services/IronLedgerLib.Services.http
@@ -62,14 +62,14 @@ Content-Type: application/json
 }
 ###
 
-# Get Components for a asset should return 200 Ok, 400 Bad Request, OR 404 Not Found
+# Get Components for an asset should return 200 Ok, 400 Bad Request, OR 404 Not Found
 GET {{IronLedgerLib.Services_HostAddress}}/api/v1/assets/68e129f573a1758c8ec462e75d0234a30c46c9f8a99359d4c75cfb2a7f0ce4f7/components
 Accept: application/json
 Content-Type: application/json
 
 ###
 
-# Patch components for a asset should return 200 Ok, 400 Bad Request, OR 404 Not Found
+# Patch components for an asset should return 200 Ok, 400 Bad Request, OR 404 Not Found
 PATCH {{IronLedgerLib.Services_HostAddress}}/api/v1/assets/68e129f573a1758c8ec462e75d0234a30c46c9f8a99359d4c75cfb2a7f0ce4f7/components
 Accept: application/json
 Content-Type: application/json
@@ -90,14 +90,14 @@ Content-Type: application/json
 }
 
 ###
-# Get Notes for a asset should return 200 Ok, 400 Bad Request, OR 404 Not Found
+# Get Notes for an asset should return 200 Ok, 400 Bad Request, OR 404 Not Found
 GET {{IronLedgerLib.Services_HostAddress}}/api/v1/assets/68e129f573a1758c8ec462e75d0234a30c46c9f8a99359d4c75cfb2a7f0ce4f7/notes
 Accept: application/json
 Content-Type: application/json
 
 ###
 
-# Patch Notes for a asset should return 200 Ok, 400 Bad Request, OR 404 Not Found
+# Patch Notes for an asset should return 200 Ok, 400 Bad Request, OR 404 Not Found
 PATCH {{IronLedgerLib.Services_HostAddress}}/api/v1/assets/68e129f573a1758c8ec462e75d0234a30c46c9f8a99359d4c75cfb2a7f0ce4f7/notes
 Accept: application/json
 Content-Type: application/json

--- a/src/IronLedgerLib.Services/IronLedgerService.cs
+++ b/src/IronLedgerLib.Services/IronLedgerService.cs
@@ -157,7 +157,7 @@ internal class IronLedgerService : IIronLedgerService
         return ExecuteWithBodyAsync(assetId, body, async payload =>
         {
             await _repository.SaveNotesAsync(assetId, payload, cancellationToken);
-            return Results.Ok();
+            return Results.Ok(assetId);
         }, cancellationToken);
     }
 

--- a/src/IronLedgerLib.Services/IronLedgerServiceExtensions.cs
+++ b/src/IronLedgerLib.Services/IronLedgerServiceExtensions.cs
@@ -1,4 +1,8 @@
-﻿namespace Tudormobile.IronLedgerLib.Services;
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+using Tudormobile.IronLedgerLib.Serialization;
+
+namespace Tudormobile.IronLedgerLib.Services;
 
 /// <summary>
 /// Provides extension methods for registering and configuring IronLedger client and service components with dependency
@@ -65,6 +69,19 @@ public static class IronLedgerServiceExtensions
         services.AddScoped<IIronLedgerService, IronLedgerService>();
         services.AddExceptionHandler<IronLedgerExceptionHandler>();
         services.AddProblemDetails();
+
+        // Ensure Results.Ok() and other minimal-API helpers serialize with the same
+        // options as IIronLedgerSerializer so naming policy, enum handling, and the
+        // ComponentPropertyConverter are consistent between requests and responses.
+        services.ConfigureHttpJsonOptions(o =>
+        {
+            foreach (var converter in IronLedgerJsonSerializer.CreateDefaultOptions().Converters)
+                o.SerializerOptions.Converters.Add(converter);
+
+            o.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower;
+            o.SerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+        });
+
         return services;
     }
 


### PR DESCRIPTION
Closes #35
- Implement Get/SetNotesAsync and Get/SetComponentsAsync in IIronLedgerClient and IronLedgerClient, with string and AssetId overloads.
- Update IronLedgerService to return assetId in SetNotesAsync responses.
- Add integration and unit tests for new client methods, covering endpoint, error, and response scenarios.
- Configure JSON serialization in IronLedgerServiceExtensions for consistent API responses (snake_case, custom converters).
- Update documentation and changelogs to reflect new endpoints and features.
- Expand IronLedgerLib.Services.http with notes/components API examples.