### PR TITLE
Add integration tests and update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Planned
 - Asset sanitation and disposal endpoints
-- Integration tests
+
+## [0.6.0] - 2026-03-25
+
+### Added
+- Bug fixes
+- Integration test project
 
 ## [0.5.0] - 2026-03-24
 

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -7,7 +7,7 @@
           "files": [
             "**/IronLedgerLib/bin/Release/net10.0/Tudormobile*.dll",
             "**/IronLedgerLib.UI/bin/Release/net10.0/Tudormobile*.UI.dll",
-            "**/IronLedgerLib.UI/bin/Release/net10.0/Tudormobile*.UI.Wpf.dll",
+            "**/IronLedgerLib.UI.Wpf/bin/Release/net10.0-windows/Tudormobile*.UI.Wpf.dll",
             "**/IronLedgerLib.Services/bin/Release/net10.0/Tudormobile*.Services.dll"
           ],
           "exclude": [

--- a/samples/AssetManager/AssetManager.csproj
+++ b/samples/AssetManager/AssetManager.csproj
@@ -7,6 +7,6 @@
     <UseWPF>true</UseWPF>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Tudormobile.IronLedgerLib.UI" Version="0.4.0" />
+    <PackageReference Include="Tudormobile.IronLedgerLib.UI.Wpf" Version="0.5.0" />
   </ItemGroup>
 </Project>

--- a/samples/AssetManager/MainWindow.xaml
+++ b/samples/AssetManager/MainWindow.xaml
@@ -4,9 +4,10 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:AssetManager"
+        xmlns:views="clr-namespace:Tudormobile.IronLedgerLib.UI.Wpf.Views;assembly=Tudormobile.IronLedgerLib.UI.Wpf"
         mc:Ignorable="d"
         Title="MainWindow" Height="450" Width="800">
     <Grid>
-
+        <views:AssetIdView/>
     </Grid>
 </Window>

--- a/samples/AssetManager/MainWindow.xaml.cs
+++ b/samples/AssetManager/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+using Tudormobile.IronLedgerLib;
 
 namespace AssetManager
 {
@@ -10,6 +11,7 @@ namespace AssetManager
         public MainWindow()
         {
             InitializeComponent();
+            this.DataContext = new AssetIdFactory().Create();
         }
     }
 }

--- a/samples/AssetManager/MainWindow.xaml.cs
+++ b/samples/AssetManager/MainWindow.xaml.cs
@@ -11,7 +11,20 @@ namespace AssetManager
         public MainWindow()
         {
             InitializeComponent();
+            this.Loaded += MainWindow_Loaded;
             this.DataContext = new AssetIdFactory().Create();
+        }
+
+        private void MainWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                this.DataContext = new AssetIdFactory().Create();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message);
+            }
         }
     }
 }

--- a/samples/AssetViewer/AssetViewer.csproj
+++ b/samples/AssetViewer/AssetViewer.csproj
@@ -7,6 +7,6 @@
     <UseWPF>true</UseWPF>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Tudormobile.IronLedgerLib.UI" Version="0.4.0" />
+    <PackageReference Include="Tudormobile.IronLedgerLib.UI" Version="0.5.0" />
   </ItemGroup>
 </Project>

--- a/samples/ServiceClient/ServiceClient.csproj
+++ b/samples/ServiceClient/ServiceClient.csproj
@@ -6,9 +6,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Tudormobile.IronLedgerLib.Services" Version="0.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
+    <PackageReference Include="Tudormobile.IronLedgerLib.Services" Version="0.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="appsettings.json" CopyToOutputDirectory="PreserveNewest" />

--- a/samples/ServiceHost/ServiceHost.csproj
+++ b/samples/ServiceHost/ServiceHost.csproj
@@ -5,6 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Tudormobile.IronLedgerLib.Services" Version="0.4.0" />
+    <PackageReference Include="Tudormobile.IronLedgerLib.Services" Version="0.5.0" />
   </ItemGroup>
 </Project>

--- a/src/IronLedger.slnx
+++ b/src/IronLedger.slnx
@@ -1,4 +1,5 @@
 <Solution>
+  <Project Path="IronLedgerLib.Integration.Tests/IronLedgerLib.Integration.Tests.csproj" />
   <Project Path="IronLedgerLib.Services/IronLedgerLib.Services.csproj" />
   <Project Path="IronLedgerLib.Services.Tests/IronLedgerLib.Services.Tests.csproj" />
   <Project Path="IronLedgerLib.Tests/IronLedgerLib.Tests.csproj" />

--- a/src/IronLedgerLib.Integration.Tests/ClientServiceTests.cs
+++ b/src/IronLedgerLib.Integration.Tests/ClientServiceTests.cs
@@ -12,6 +12,7 @@ public class ClientServiceTests
     private static WebApplication _app = null!;
     private static IIronLedgerClient _client = null!;
     private static string _tempPath = null!;
+    private static HttpClient _httpClient;
 
     public TestContext TestContext { get; set; } = null!;
 
@@ -34,7 +35,8 @@ public class ClientServiceTests
             .Features.Get<IServerAddressesFeature>()!
             .Addresses.First();
 
-        _client = IIronLedgerClient.Create(new HttpClient { BaseAddress = new Uri(address) });
+        _httpClient = new HttpClient { BaseAddress = new Uri(address) };
+        _client = IIronLedgerClient.Create(_httpClient);
     }
 
     [ClassCleanup]
@@ -44,6 +46,7 @@ public class ClientServiceTests
         await _app.DisposeAsync();
         if (Directory.Exists(_tempPath))
             Directory.Delete(_tempPath, recursive: true);
+        _httpClient.Dispose();
     }
 
     [TestMethod]

--- a/src/IronLedgerLib.Integration.Tests/ClientServiceTests.cs
+++ b/src/IronLedgerLib.Integration.Tests/ClientServiceTests.cs
@@ -1,0 +1,110 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace IronLedgerLib.Integration.Tests;
+
+[TestCategory("Integration")]
+[TestClass]
+public class ClientServiceTests
+{
+    private static WebApplication _app = null!;
+    private static IIronLedgerClient _client = null!;
+    private static string _tempPath = null!;
+
+    public TestContext TestContext { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInitialize(TestContext _)
+    {
+        _tempPath = Path.Combine(Path.GetTempPath(), $"IronLedgerIntTest_{Guid.NewGuid():N}");
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddIronLedgerService(o => o.DataPath = _tempPath);
+
+        _app = builder.Build();
+        _app.Urls.Add("http://127.0.0.1:0");
+        _app.UseIronLedgerService();
+
+        await _app.StartAsync();
+
+        var address = _app.Services
+            .GetRequiredService<IServer>()
+            .Features.Get<IServerAddressesFeature>()!
+            .Addresses.First();
+
+        _client = IIronLedgerClient.Create(new HttpClient { BaseAddress = new Uri(address) });
+    }
+
+    [ClassCleanup]
+    public static async Task ClassCleanup()
+    {
+        await _app.StopAsync();
+        await _app.DisposeAsync();
+        if (Directory.Exists(_tempPath))
+            Directory.Delete(_tempPath, recursive: true);
+    }
+
+    [TestMethod]
+    public async Task GetStatus_ReturnsSuccess()
+    {
+        var response = await _client.GetStatusAsync(TestContext.CancellationToken);
+
+        Assert.IsTrue(response.IsSuccess);
+        Assert.IsNotNull(response.Data);
+    }
+
+    [TestMethod]
+    public async Task CreateAsset_NewAsset_ReturnsMatchingId()
+    {
+        var assetId = MakeUniqueAssetId();
+
+        var response = await _client.CreateAssetAsync(assetId, TestContext.CancellationToken);
+
+        Assert.IsTrue(response.IsSuccess, response.ErrorMessage);
+        Assert.AreEqual(assetId.Id, response.Data);
+    }
+
+    [TestMethod]
+    public async Task CreateAsset_DuplicateAsset_ReturnsFailure()
+    {
+        var assetId = MakeUniqueAssetId();
+        await _client.CreateAssetAsync(assetId, TestContext.CancellationToken);
+
+        var second = await _client.CreateAssetAsync(assetId, TestContext.CancellationToken);
+
+        Assert.IsFalse(second.IsSuccess);
+    }
+
+    [TestMethod]
+    public async Task GetAssetIds_AfterCreatingAsset_ContainsCreatedId()
+    {
+        var assetId = MakeUniqueAssetId();
+        await _client.CreateAssetAsync(assetId, TestContext.CancellationToken);
+
+        var response = await _client.GetAssetIdsAsync(TestContext.CancellationToken);
+
+        Assert.IsTrue(response.IsSuccess, response.ErrorMessage);
+        CollectionAssert.Contains(response.Data, assetId.Id);
+    }
+
+    [TestMethod]
+    public async Task GetAsset_AfterCreating_ReturnsMatchingRecord()
+    {
+        var assetId = MakeUniqueAssetId();
+        await _client.CreateAssetAsync(assetId, TestContext.CancellationToken);
+
+        var response = await _client.GetAssetAsync(assetId.Id, TestContext.CancellationToken);
+
+        Assert.IsTrue(response.IsSuccess, response.ErrorMessage);
+        Assert.AreEqual(assetId.Id, response.Data?.Id.Id);
+    }
+
+    private static AssetId MakeUniqueAssetId() => new()
+    {
+        SystemMetadata = new AssetMetadata { SerialNumber = Guid.NewGuid().ToString("N"), Manufacturer = "IntegrationTest", Product = "TestProduct" },
+        BaseBoardMetadata = AssetMetadata.Empty,
+        BiosMetadata = AssetMetadata.Empty,
+    };
+}

--- a/src/IronLedgerLib.Integration.Tests/DefaultTests.cs
+++ b/src/IronLedgerLib.Integration.Tests/DefaultTests.cs
@@ -1,0 +1,16 @@
+﻿namespace IronLedgerLib.Integration.Tests;
+
+[TestClass]
+public class DefaultTests
+{
+    [TestMethod]
+    public void DefaultTest()
+    {
+        // Each test project requires at least one test to 'succeed'. this default
+        // test allows this project to 'succeed' even if we filter out all integration
+        // tests.
+#pragma warning disable MSTEST0032 // Assertion condition is always true
+        Assert.IsTrue(true);
+#pragma warning restore MSTEST0032 // Assertion condition is always true
+    }
+}

--- a/src/IronLedgerLib.Integration.Tests/IronLedgerLib.Integration.Tests.csproj
+++ b/src/IronLedgerLib.Integration.Tests/IronLedgerLib.Integration.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSTest.Sdk/4.1.0">
+<Project Sdk="MSTest.Sdk/4.1.0">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>

--- a/src/IronLedgerLib.Integration.Tests/MSTestSettings.cs
+++ b/src/IronLedgerLib.Integration.Tests/MSTestSettings.cs
@@ -1,0 +1,1 @@
+﻿[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]

--- a/src/IronLedgerLib.Tests/IronLedgerLib.Tests.csproj
+++ b/src/IronLedgerLib.Tests/IronLedgerLib.Tests.csproj
@@ -14,4 +14,7 @@
     <Using Include="System.Globalization" />
     <Using Include="Tudormobile.IronLedgerLib" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
+  </ItemGroup>
 </Project>

--- a/src/IronLedgerLib.UI.Tests/IronLedgerLib.UI.Tests.csproj
+++ b/src/IronLedgerLib.UI.Tests/IronLedgerLib.UI.Tests.csproj
@@ -15,4 +15,7 @@
     <Using Include="Tudormobile.IronLedgerLib" />
     <Using Include="Tudormobile.IronLedgerLib.UI" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
+  </ItemGroup>
 </Project>

--- a/src/IronLedgerLib.UI.Wpf.Tests/IronLedgerLib.UI.Wpf.Tests.csproj
+++ b/src/IronLedgerLib.UI.Wpf.Tests/IronLedgerLib.UI.Wpf.Tests.csproj
@@ -17,4 +17,7 @@
     <Using Include="Tudormobile.IronLedgerLib.UI" />
     <Using Include="Tudormobile.IronLedgerLib.UI.Wpf" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
+  </ItemGroup>
 </Project>

--- a/src/IronLedgerLib.UI/IronLedgerLib.UI.csproj
+++ b/src/IronLedgerLib.UI/IronLedgerLib.UI.csproj
@@ -26,7 +26,7 @@
     <InternalsVisibleTo Include="$(MSBuildProjectName).Tests" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />  
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />  
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\IronLedgerLib\IronLedgerLib.csproj" />


### PR DESCRIPTION
Fixes #40
Introduce IronLedgerLib.Integration.Tests for end-to-end API testing using MSTest and in-memory hosting. Enable MSTest parallelization. Update all test projects to use Microsoft.Testing.Extensions.CodeCoverage v18.5.2. Bump package versions across projects, including CommunityToolkit.Mvvm and IronLedgerLib.Services. Update AssetManager to use the new WPF UI package and AssetIdView. Adjust docfx.json for new WPF DLL path. Update changelog for v0.6.0.